### PR TITLE
Update `pyproject.toml` for Poetry 1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ distributed = ["distributed", "bokeh"]
 cloud = ["s3fs", "gcsfs", "adlfs"]
 lossy = ["zfpy"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^22.6.0"
 coverage = {version = "^6.4.4", extras = ["toml"]}
 darglint = "^1.8.1"


### PR DESCRIPTION
Poetry released version 1.2 with major improvements.

One breaking change (not deprecated yet) is the new dependency groups.

Updating `pyproject.toml` to new standard.
