### PR TITLE
Improved ZFP compression quality using `FIXED-ACCURACY` mode

### DIFF
--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -123,12 +123,12 @@ cli = click.Group(name="segy", help=SEGY_HELP)
     show_default=True,
 )
 @click.option(
-    "-ratio",
-    "--compression-ratio",
+    "-tolerance",
+    "--compression-tolerance",
     required=False,
-    default=4,
-    help="Lossy compression ratio.",
-    type=click.INT,
+    default=0.01,
+    help="Lossy compression tolerance in ZFP.",
+    type=click.FLOAT,
     show_default=True,
 )
 @click.option(
@@ -156,7 +156,7 @@ def segy_import(
     chunk_size,
     endian,
     lossless,
-    compression_ratio,
+    compression_tolerance,
     storage_options,
     overwrite,
 ):
@@ -213,13 +213,18 @@ def segy_import(
 
     By default, the data is ingested with LOSSLESS compression. This
     saves disk space in the range of 20% to 40%. MDIO also allows
-    data to be compressed using the ZFP compressor's fixed rate lossy
-    compression. If lossless parameter is set to False and MDIO was
-    installed using the lossy extra; then the data will be compressed
+    data to be compressed using the ZFP compressor's fixed accuracy
+    lossy compression. If lossless parameter is set to False and MDIO
+    was installed using the lossy extra; then the data will be compressed
     to approximately 30% of its original size and will be perceptually
-    lossless. The compression ratio can be adjusted using the option
-    compression_ratio (integer). Higher values will compress more, but
-    will introduce artifacts.
+    lossless. The compression amount can be adjusted using the option
+    compression_tolerance (float). Values less than 1 gives good results.
+    The higher the value, the more compression, but will introduce artifacts.
+    The default value is 0.01 tolerance, however we get good results
+    up to 0.5; where data is almost compressed to 10% of its original size.
+    NOTE: This assumes data has amplitudes normalized to have approximately
+    standard deviation of 1. If dataset has values smaller than this
+    tolerance, a lot of loss may occur.
 
     Usage:
 
@@ -265,7 +270,7 @@ def segy_import(
         chunksize=chunk_size,
         endian=endian,
         lossless=lossless,
-        compression_ratio=compression_ratio,
+        compression_tolerance=compression_tolerance,
         storage_options=storage_options,
         overwrite=overwrite,
     )

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -36,7 +36,7 @@ def segy_to_mdio(
     chunksize: Sequence[int] | None = None,
     endian: str = "big",
     lossless: bool = True,
-    compression_ratio: int | float = 4,
+    compression_tolerance: float = 0.01,
     storage_options: dict[str, Any] | None = None,
     overwrite: bool = False,
 ) -> None:
@@ -84,8 +84,10 @@ def segy_to_mdio(
         endian: Endianness of the input SEG-Y. Rev.2 allows little endian.
             Default is 'big'. Must be in `{"big", "little"}`
         lossless: Lossless Blosc with zstandard, or ZFP with fixed precision.
-        compression_ratio: Approximate compression ratio for ZFP compression.
-            Will be ignored if `lossless=True`
+        compression_tolerance: Tolerance ZFP compression, optional. The fixed
+            accuracy mode in ZFP guarantees there won't be any errors larger
+            than this value. The default is 0.01, which gives about 70%
+            reduction in size. Will be ignored if `lossless=True`.
         storage_options: Storage options for the cloud storage backend.
             Default is `None` (will assume anonymous)
         overwrite: Toggle for overwriting existing store
@@ -253,7 +255,7 @@ def segy_to_mdio(
         dtype="float32",
         chunks=chunksize,
         lossless=lossless,
-        compression_ratio=compression_ratio,
+        compression_tolerance=compression_tolerance,
     )
 
     for key, value in stats.items():


### PR DESCRIPTION
We used to use `FIXED-RATE` compression to achieve predictable compression ratios. However, this does introduce some large errors.

After benchmarking, we see that `FIXED-ACCURACY` with a tolerance achieves similar compression ratios with significantly fewer compression artifacts. 

This PR changes the compression method and set a reasonable default.

The default value of `0.01` will guarantee that compressed data will have reconstruction errors less than that value. Typically this compresses seismic data to 20-25% of its size.

The results with a tolerance of `0.1` or higher like `1` are also acceptable for visualization applications and provide about 90% or more reduction in size.

Note that this number must be reduced if the dataset has very small values/variations. The data will become less compressible if we store very small numbers (like `1e-5` levels).

References:
https://zfp.readthedocs.io/en/release1.0.0/introduction.html
https://www.blosc.org/posts/support-lossy-zfp/

- [X] Tests passes
- [X] Documentation is updated
- [X] Linter passes