### PR TITLE
Don't fail when EBCDIC decoding has an error.

### DIFF
--- a/src/mdio/segy/parsers.py
+++ b/src/mdio/segy/parsers.py
@@ -63,7 +63,7 @@ def parse_text_header(segy_handle: segyio.SegyFile) -> list[str]:
     Returns:
         Parsed text header in list with lines as elements.
     """
-    text_header = segy_handle.text[0].decode(errors='ignore')
+    text_header = segy_handle.text[0].decode(errors="ignore")
     text_header = [
         text_header[char_idx : char_idx + 80]
         for char_idx in range(0, len(text_header), 80)

--- a/src/mdio/segy/parsers.py
+++ b/src/mdio/segy/parsers.py
@@ -63,7 +63,7 @@ def parse_text_header(segy_handle: segyio.SegyFile) -> list[str]:
     Returns:
         Parsed text header in list with lines as elements.
     """
-    text_header = segy_handle.text[0].decode()
+    text_header = segy_handle.text[0].decode(errors='ignore')
     text_header = [
         text_header[char_idx : char_idx + 80]
         for char_idx in range(0, len(text_header), 80)


### PR DESCRIPTION
Closes #50 

Petrel EBCDIC appear to require encoding='ISO-8859-1' rather than the default UTF-8.

This causes an error when decoding these files. We ignore the errors with a flag in `segyio`.

Thanks to @gmac161 for pointing it out.