### PR TITLE
Use dimension separator in arrays instead of `FSStore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /dist/
 /docs/_build/
 /src/*.egg-info/
-*__pycache__/
+/*__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /dist/
 /docs/_build/
 /src/*.egg-info/
+*__pycache__/

--- a/src/mdio/api/io_utils.py
+++ b/src/mdio/api/io_utils.py
@@ -66,7 +66,6 @@ def process_url(
         check=check,
         create=check,
         mode=mode,
-        dimension_separator="/",
         **storage_options,
     )
 

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -213,6 +213,7 @@ def segy_to_mdio(
         name="live_mask",
         shape=grid.shape[:-1],
         chunks=-1,
+        dimension_separator="/",
     )
 
     write_attribute(

--- a/src/mdio/segy/blocked_io.py
+++ b/src/mdio/segy/blocked_io.py
@@ -86,6 +86,7 @@ def to_zarr(
         shape=grid.shape,
         compressor=trace_compressor,
         chunks=chunks,
+        dimension_separator="/",
         **kwargs,
     )
 
@@ -116,6 +117,7 @@ def to_zarr(
         chunks=chunks[:-1],  # Same spatial chunks as data
         compressor=header_compressor,
         dtype=header_dtype,
+        dimension_separator="/",
     )
 
     # Initialize chunk iterator (returns next chunk slice indices each iteration)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,7 +33,7 @@ TEST_DIMS = {
 def mock_store(tmp_path_factory):
     """Make a mocked MDIO store for writing."""
     tmp_dir = tmp_path_factory.mktemp("mdio")
-    return FSStore(tmp_dir.name, dimension_separator="/")
+    return FSStore(tmp_dir.name)
 
 
 @pytest.fixture
@@ -106,6 +106,7 @@ def mock_mdio(
         name="live_mask",
         shape=grid.shape[:-1],
         chunks=-1,
+        dimension_separator="/",
     )
 
     write_attribute(name="created", zarr_group=zarr_root, attribute=str(datetime.now()))
@@ -124,13 +125,18 @@ def mock_mdio(
     for key, value in stats.items():
         write_attribute(name=key, zarr_group=zarr_root, attribute=value)
 
-    data_arr = data_grp.create_dataset("chunked_012", data=mock_data)
+    data_arr = data_grp.create_dataset(
+        "chunked_012",
+        data=mock_data,
+        dimension_separator="/",
+    )
 
     metadata_grp.create_dataset(
         data=il_grid * xl_grid,
         name="_".join(["chunked_012", "trace_headers"]),
         shape=grid.shape[:-1],  # Same spatial shape as data
         chunks=data_arr.chunks[:-1],  # Same spatial chunks as data
+        dimension_separator="/",
     )
 
     consolidate_metadata(mock_store)


### PR DESCRIPTION
Move all usage of `dimension_separator` from Zarr stores to individual Zarr arrays, in order to avoid `.zmetadata` dimension separator bug