### PR TITLE
Pass package version to CLI command explicitly

### DIFF
--- a/src/mdio/__main__.py
+++ b/src/mdio/__main__.py
@@ -70,7 +70,7 @@ class MyCLI(click.MultiCommand):
 
 
 @click.command(cls=MyCLI)
-@click.version_option()
+@click.version_option(mdio.__version__)
 def main() -> None:
     """Welcome to MDIO!
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,3 +25,10 @@ def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> No
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0
+
+
+def test_cli_version(runner: CliRunner) -> None:
+    """Check if version prints without error."""
+    cli_args = ["--version"]
+    result = runner.invoke(__main__.main, args=cli_args)
+    assert result.exit_code == 0


### PR DESCRIPTION
closes #55 

Since the package name is `mdio` and installation is `Multidimio`, `click` couldn't find the package version by itself. To fix this and avoid future issues, we pass the version explicitly.