### PR TITLE
Add markdown extension for trailing whitespace fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,7 @@ repos:
         language: system
         types: [text]
         stages: [commit, push, manual]
+        args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.0
     hooks:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,11 +68,11 @@ Credentials can be automatically fetched from pre-authenticated AWS CLI.
 See [here](https://s3fs.readthedocs.io/en/latest/index.html#credentials) for the order `s3fs`
 checks them. If it is not pre-authenticated, you need to pass `--storage-options`.
 
-**Prefix:**
+**Prefix:**  
 `s3://`
 
-**Storage Options:**
-`key`: The auth key from AWS
+**Storage Options:**  
+`key`: The auth key from AWS  
 `secret`: The auth secret from AWS
 
 Using UNIX:
@@ -104,10 +104,10 @@ checks them. If it is not pre-authenticated, you need to pass `--storage-options
 GCP uses [service accounts](https://cloud.google.com/iam/docs/service-accounts) to pass
 authentication information to APIs.
 
-**Prefix:**
+**Prefix:**  
 `gs://` or `gcs://`
 
-**Storage Options:**
+**Storage Options:**  
 `token`: The service account JSON value as string, or local path to JSON
 
 Using a service account:
@@ -136,11 +136,11 @@ There are various ways to authenticate with Azure Data Lake (ADL).
 See [here](https://github.com/fsspec/adlfs#details) for some details.
 If ADL is not pre-authenticated, you need to pass `--storage-options`.
 
-**Prefix:**
+**Prefix:**  
 `az://` or `abfs://`
 
-**Storage Options:**
-`account_name`: Azure Data Lake storage account name
+**Storage Options:**  
+`account_name`: Azure Data Lake storage account name  
 `account_key`: Azure Data Lake storage account access key
 
 ```shell


### PR DESCRIPTION
trailing whitespace pre-commit was stripping intentional line breaks (double spaces) from markdown files. This adds an extension to stop it from doing that. Also fixed some broken line breaks.