### PR TITLE
Fix inconsistent accessor header chunking when Dask backend is used.

### DIFF
--- a/src/mdio/api/accessor.py
+++ b/src/mdio/api/accessor.py
@@ -269,7 +269,7 @@ class MDIOAccessor:
         )
 
         if self._backend == "dask":
-            trace_kwargs["chunks"] = self.chunks[:-1]
+            header_kwargs["chunks"] = self.chunks[:-1]
 
         self._headers = self._array_loader(**header_kwargs)
 


### PR DESCRIPTION
Header chunks weren't initialized correctly. The keyword arguments for headers were incorrect hence caused auto adjustment of header virtual chunks.