### PR TITLE
Bump minimum Dask / Distributed version requirement to `2022.11.0` and get memory improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ python = ">=3.8,<3.11"
 click = "^8.1.3"
 click-params = "^0.3.0"
 zarr = "^2.12.0"
-dask = "^2022.8.1"
+dask = "^2022.11.0"
 tqdm = "^4.64.0"
 segyio = "^1.9.3"
 numba = ">=0.55.2,<1.0.0"
 psutil = "^5.9.1"
-distributed = {version = "^2022.8.1", optional = true}
+distributed = {version = "^2022.11.0", optional = true}
 bokeh = {version = "^2.4.3", optional = true}
 s3fs = {version = "^2022.7.0", optional = true}
 gcsfs = {version = "^2022.7.0", optional = true}


### PR DESCRIPTION
Due to the new default `queuing` system being kind of a deal breaker.

https://blog.dask.org/2022/11/15/queuing

https://github.com/TGSAI/mdio-python/pull/109
