### PR TITLE
Ensure Copied MDIO Has Fill Value of Zero

### DIFF
--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -65,11 +65,10 @@ def copy_mdio(
         source_array = source.root[data_path]
         dimension_separator = source_array._dimension_separator
 
-        zarr.empty_like(
+        zarr.zeros_like(
             source_array,
             store=dest_store,
             path=data_path,
             overwrite=overwrite,
             dimension_separator=dimension_separator,
-            fill_value=0,
         )

--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -71,4 +71,5 @@ def copy_mdio(
             path=data_path,
             overwrite=overwrite,
             dimension_separator=dimension_separator,
+            fill_value=0,
         )


### PR DESCRIPTION
It was defaulting to NaN for some reason.