### PR TITLE
Fix crash when exporting to SEG-Y with missing `axis=0` chunk in `selection_mask`

### DIFF
--- a/src/mdio/converters/mdio.py
+++ b/src/mdio/converters/mdio.py
@@ -178,6 +178,10 @@ def mdio_to_segy(  # noqa: C901
                 axis=tuple(range(1, samples.ndim)),
             ).compute()
 
+        # If whole blocks are missing, remove them from the list.
+        missing_mask = flat_files == "missing"
+        flat_files = flat_files[~missing_mask]
+
         final_concat = [output_segy_path] + flat_files.tolist()
 
         if client is not None:


### PR DESCRIPTION
This PR addresses a crash that occurred when exporting to SEG-Y format and an entire `axis=0` chunk was missing from the `selection_mask`. The following changes have been made in the `mdio_to_segy` function within `mdio.py`:

1. Added a condition to handle missing whole blocks by filtering them out from the `flat_files` array.
2. Concatenate the output SEG-Y file with the filtered `flat_files` list.