### PR TITLE
New CLI Options for Copy and Extract Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ mdio1/*
 */mdio1/*
 pytest-of-*
 tmp
+debugging/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 pip-*
-*pytest*
 tmp*
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -152,4 +151,4 @@ cython_debug/
 mdio1/*
 */mdio1/*
 pytest-of-*
-tmp/
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
+pip-*
+*pytest*
+tmp*
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/noxfile.py
+++ b/noxfile.py
@@ -132,6 +132,7 @@ def precommit(session: Session) -> None:
         "pre-commit",
         "pre-commit-hooks",
         "pyupgrade",
+        "pytest-dependency",
     )
     session.run("pre-commit", *args)
     if args and args[0] == "install":

--- a/src/mdio/__main__.py
+++ b/src/mdio/__main__.py
@@ -11,6 +11,7 @@ import click_params
 
 import mdio
 
+from mdio.commands.utility import copy, info
 
 plugin_folder = os.path.join(os.path.dirname(__file__), "commands")
 
@@ -40,11 +41,18 @@ class MyCLI(click.MultiCommand):
         http://lybniz2.sourceforge.net/safeeval.html
     """
 
+    _command_mapping = {
+        "copy": copy,
+        "info": info,
+    }
+
+    protected_files = ["__init__.py", "utility.py"]
+
     def list_commands(self, ctx: click.Context) -> list[str]:
         """List commands available under `commands` module."""
-        rv = []
+        rv = list(self._command_mapping.keys())
         for filename in os.listdir(plugin_folder):
-            if filename.endswith(".py") and filename != "__init__.py":
+            if filename.endswith(".py") and filename not in self.protected_files:
                 rv.append(filename[:-3])
         rv.sort()
 
@@ -61,6 +69,8 @@ class MyCLI(click.MultiCommand):
         }
         local_ns = {}
 
+        if name in self._command_mapping.keys():
+            return self._command_mapping[name]
         fn = os.path.join(plugin_folder, name + ".py")
         with open(fn) as f:
             code = compile(f.read(), fn, "exec")

--- a/src/mdio/__main__.py
+++ b/src/mdio/__main__.py
@@ -10,8 +10,9 @@ import click
 import click_params
 
 import mdio
+from mdio.commands.utility import copy
+from mdio.commands.utility import info
 
-from mdio.commands.utility import copy, info
 
 plugin_folder = os.path.join(os.path.dirname(__file__), "commands")
 

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -27,9 +27,19 @@ except SystemError:
     type=click.STRING,
 )
 @click.option(
+    "-access",
+    "--access-pattern",
+    required=False,
+    default="012",
+    help="Access pattern of the file",
+    type=click.STRING,
+    show_default=True,
+)
+@click.option(
     "-exc",
     "--excludes",
     required=False,
+    default="",
     help="""Data to exclude during copy. i.e. chunked_012. The raw data won’t be
     copied, but it will create an empty array to be filled. If left blank, it will
     copy everything.""",
@@ -39,6 +49,7 @@ except SystemError:
     "-inc",
     "--includes",
     required=False,
+    default="",
     help="""Data to include during copy. i.e. trace_headers. If this is not
     specified, and certain data is excluded, it will not copy headers. To
     preserve headers, specify trace_headers. If left blank, it will copy
@@ -62,8 +73,9 @@ except SystemError:
     show_default=True,
 )
 def copy(
-    input_mdio_path,
+    input_mdio_path: str,
     output_mdio_path: str,
+    access_pattern: str = "012",
     includes: str = "",
     excludes: str = "",
     storage_options: Optional[dict] = None,
@@ -77,8 +89,11 @@ def copy(
     More documentation about `excludes` and `includes` can be found
     in Zarr's documentation in `zarr.convenience.copy_store`.
     """
+    reader = mdio.MDIOReader(
+        input_mdio_path, access_pattern=access_pattern, return_metadata=True
+    )
     mdio.copy_mdio(
-        source=input_mdio_path,
+        source=reader,
         dest_path_or_buffer=output_mdio_path,
         excludes=excludes,
         includes=includes,

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -1,0 +1,167 @@
+"""Dataset CLI Plugin."""
+
+
+try:
+    import click
+    import click_params
+
+    import mdio
+    import json
+except SystemError:
+    pass
+
+
+DEFAULT_HELP = """
+MDIO CLI utilities. 
+"""
+
+
+@click.group(help=DEFAULT_HELP)
+def cli():
+    click.echo(f"MDIO CLI utilities")
+
+
+@cli.command(name="copy")
+@click.option(
+    "-i",
+    "--input-mdio-path",
+    required=True,
+    help="Input mdio path.",
+    type=click.Path(exists=True),
+)
+@click.option(
+    "-o",
+    "--output-mdio-path",
+    required=True,
+    help="Output path or URL to write the mdio dataset.",
+    type=click.STRING,
+)
+@click.option(
+    "-exc",
+    "--excludes",
+    required=False,
+    help="Data to exclude during copy. i.e. chunked_012. The raw data won’t be copied, but it will create an empty array to be filled. If left blank, it will copy everything.",
+    type=click.STRING,
+)
+@click.option(
+    "-inc",
+    "--includes",
+    required=False,
+    help="Data to include during copy. i.e. trace_headers. If this is not specified, and certain data is excluded, it will not copy headers. If you want to preserve headers, specify trace_headers. If left blank, it will copy everything except specified in excludes parameter.",
+    type=click.STRING,
+)
+@click.option(
+    "-storage",
+    "--storage-options",
+    required=False,
+    help="Custom storage options for cloud backends",
+    type=click_params.JSON,
+)
+@click.option(
+    "-overwrite",
+    "--overwrite",
+    required=False,
+    default=False,
+    help="Flag to overwrite if mdio file if it exists",
+    type=click.BOOL,
+    show_default=True,
+)
+def copy(
+    input_mdio_path,
+    output_mdio_path: str,
+    includes: str = "",
+    excludes: str = "",
+    storage_options: dict | None = None,
+    overwrite: bool = False,
+):
+    """Copy MDIO to MDIO.
+    Can also copy with empty data to be filled later. See `excludes`
+    and `includes` parameters.
+
+    More documentation about `excludes` and `includes` can be found
+    in Zarr's documentation in `zarr.convenience.copy_store`.
+
+    Args:
+        source: MDIO reader or accessor instance. Data will be copied from here
+        dest_path_or_buffer: Destination path. Could be any FSSpec mapping.
+        excludes: Data to exclude during copy. i.e. `chunked_012`. The raw data
+            won't be copied, but it will create an empty array to be filled.
+            If left blank, it will copy everything.
+        includes: Data to include during copy. i.e. `trace_headers`. If this is
+            not specified, and certain data is excluded, it will not copy headers.
+            If you want to preserve headers, specify `trace_headers`. If left blank,
+            it will copy everything except specified in `excludes` parameter.
+        storage_options: Storage options for the cloud storage backend.
+            Default is None (will assume anonymous).
+        overwrite: Overwrite destination or not.
+    """
+    mdio.copy_mdio(
+        source=input_mdio_path,
+        dest_path_or_buffer=output_mdio_path,
+        excludes=excludes,
+        includes=includes,
+        storage_options=storage_options,
+        overwrite=overwrite,
+    )
+
+
+@cli.command(name="info")
+@click.option(
+    "-i",
+    "--input-mdio-file",
+    required=True,
+    help="Input path of the mdio file",
+    type=click.STRING,
+)
+@click.option(
+    "-format",
+    "--output-format",
+    required=False,
+    default="plain",
+    help="Output format, plain is human readable.  JSON will output in json format for easier passing. ",
+    type=click.Choice(["plain", "json"]),
+    show_default=True,
+    show_choices=True,
+)
+def info(
+    input_mdio_file,
+    output_format,
+):
+    """Provide information on MDIO dataset.
+
+    By default this returns human readable information about the grid and stats for the dataset. If output-format is set to json then a json is returned to facilitate parsing
+
+
+    """
+    reader = mdio.MDIOReader(input_mdio_file, return_metadata=True)
+    mdio_dict = {}
+    mdio_dict["grid"] = {}
+    for axis in reader.grid.dim_names:
+        dim = reader.grid.select_dim(axis)
+        min = dim.coords[0]
+        max = dim.coords[-1]
+        size = dim.coords.shape[0]
+        axis_dict = {"name": axis, "min": min, "max": max, "size": size}
+        mdio_dict["grid"][axis] = axis_dict
+
+    if output_format == "plain":
+        click.echo("{:<10} {:<10} {:<10} {:<10}".format("NAME", "MIN", "MAX", "SIZE"))
+        click.echo("=" * 40)
+
+        for _, axis_dict in mdio_dict["grid"].items():
+            click.echo(
+                "{:<10} {:<10} {:<10} {:<10}".format(
+                    axis_dict["name"],
+                    axis_dict["min"],
+                    axis_dict["max"],
+                    axis_dict["size"],
+                )
+            )
+
+        click.echo("\n\n{:<10} {:<10}".format("STAT", "VALUE"))
+        click.echo("=" * 20)
+        for name, stat in reader.stats.items():
+            click.echo("{:<10} {:<10}".format(name, stat))
+    if output_format == "json":
+        mdio_dict["stats"] = reader.stats
+        click.echo(mdio_dict)

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -40,14 +40,19 @@ def cli():
     "-exc",
     "--excludes",
     required=False,
-    help="Data to exclude during copy. i.e. chunked_012. The raw data won’t be copied, but it will create an empty array to be filled. If left blank, it will copy everything.",
+    help="""Data to exclude during copy. i.e. chunked_012. The raw data won’t be
+    copied, but it will create an empty array to be filled. If left blank, it will
+    copy everything.""",
     type=click.STRING,
 )
 @click.option(
     "-inc",
     "--includes",
     required=False,
-    help="Data to include during copy. i.e. trace_headers. If this is not specified, and certain data is excluded, it will not copy headers. If you want to preserve headers, specify trace_headers. If left blank, it will copy everything except specified in excludes parameter.",
+    help="""Data to include during copy. i.e. trace_headers. If this is not 
+    specified, and certain data is excluded, it will not copy headers. If you want
+    to preserve headers, specify trace_headers. If left blank, it will copy
+    everything except specified in excludes parameter.""",
     type=click.STRING,
 )
 @click.option(
@@ -118,7 +123,8 @@ def copy(
     "--output-format",
     required=False,
     default="plain",
-    help="Output format, plain is human readable.  JSON will output in json format for easier passing. ",
+    help="""Output format, plain is human readable.  JSON will output in json 
+    format for easier passing. """,
     type=click.Choice(["plain", "json"]),
     show_default=True,
     show_choices=True,
@@ -129,9 +135,9 @@ def info(
 ):
     """Provide information on MDIO dataset.
 
-    By default this returns human readable information about the grid and stats for the dataset. If output-format is set to json then a json is returned to facilitate parsing
-
-
+    By default this returns human readable information about the grid and stats for
+    the dataset. If output-format is set to json then a json is returned to
+    facilitate parsing.
     """
     reader = mdio.MDIOReader(input_mdio_file, return_metadata=True)
     mdio_dict = {}

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -120,6 +120,15 @@ def copy(
     type=click.STRING,
 )
 @click.option(
+    "-access",
+    "--access-pattern",
+    required=False,
+    default="012",
+    help="Access pattern of the file",
+    type=click.STRING,
+    show_default=True,
+)
+@click.option(
     "-format",
     "--output-format",
     required=False,
@@ -133,6 +142,7 @@ def copy(
 def info(
     input_mdio_file,
     output_format,
+    access_pattern,
 ):
     """Provide information on MDIO dataset.
 
@@ -140,7 +150,9 @@ def info(
     the dataset. If output-format is set to json then a json is returned to
     facilitate parsing.
     """
-    reader = mdio.MDIOReader(input_mdio_file, return_metadata=True)
+    reader = mdio.MDIOReader(
+        input_mdio_file, access_pattern=access_pattern, return_metadata=True
+    )
     mdio_dict = {}
     mdio_dict["grid"] = {}
     for axis in reader.grid.dim_names:

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -11,17 +11,6 @@ except SystemError:
     pass
 
 
-DEFAULT_HELP = """
-MDIO CLI utilities.
-"""
-
-
-@click.group(help=DEFAULT_HELP)
-def cli():
-    """Setup click group."""
-    click.echo("MDIO CLI utilities")
-
-
 @click.command(name="copy")
 @click.option(
     "-i",
@@ -51,8 +40,8 @@ def cli():
     "--includes",
     required=False,
     help="""Data to include during copy. i.e. trace_headers. If this is not
-    specified, and certain data is excluded, it will not copy headers. If you want
-    to preserve headers, specify trace_headers. If left blank, it will copy
+    specified, and certain data is excluded, it will not copy headers. To
+    preserve headers, specify trace_headers. If left blank, it will copy
     everything except specified in excludes parameter.""",
     type=click.STRING,
 )
@@ -80,27 +69,13 @@ def copy(
     storage_options: Optional[dict] = None,
     overwrite: bool = False,
 ):
-    """Copy MDIO to MDIO.
+    """Copy a MDIO dataset to anpther MDIO dataset.
 
     Can also copy with empty data to be filled later. See `excludes`
     and `includes` parameters.
 
     More documentation about `excludes` and `includes` can be found
     in Zarr's documentation in `zarr.convenience.copy_store`.
-
-    Args:
-        input_mdio_path: MDIO reader or accessor instance. Data will be copied from here
-        output_mdio_path: Destination path. Could be any FSSpec mapping.
-        excludes: Data to exclude during copy. i.e. `chunked_012`. The raw data
-            won't be copied, but it will create an empty array to be filled.
-            If left blank, it will copy everything.
-        includes: Data to include during copy. i.e. `trace_headers`. If this is
-            not specified, and certain data is excluded, it will not copy headers.
-            If you want to preserve headers, specify `trace_headers`. If left blank,
-            it will copy everything except specified in `excludes` parameter.
-        storage_options: Storage options for the cloud storage backend.
-            Default is None (will assume anonymous).
-        overwrite: Overwrite destination or not.
     """
     mdio.copy_mdio(
         source=input_mdio_path,
@@ -145,7 +120,7 @@ def info(
     output_format,
     access_pattern,
 ):
-    """Provide information on MDIO dataset.
+    """Provide information on a MDIO dataset.
 
     By default this returns human readable information about the grid and stats for
     the dataset. If output-format is set to json then a json is returned to

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -6,19 +6,19 @@ try:
     import click_params
 
     import mdio
-    import json
 except SystemError:
     pass
 
 
 DEFAULT_HELP = """
-MDIO CLI utilities. 
+MDIO CLI utilities.
 """
 
 
 @click.group(help=DEFAULT_HELP)
 def cli():
-    click.echo(f"MDIO CLI utilities")
+    """Setup click group."""
+    click.echo("MDIO CLI utilities")
 
 
 @cli.command(name="copy")
@@ -49,7 +49,7 @@ def cli():
     "-inc",
     "--includes",
     required=False,
-    help="""Data to include during copy. i.e. trace_headers. If this is not 
+    help="""Data to include during copy. i.e. trace_headers. If this is not
     specified, and certain data is excluded, it will not copy headers. If you want
     to preserve headers, specify trace_headers. If left blank, it will copy
     everything except specified in excludes parameter.""",
@@ -80,6 +80,7 @@ def copy(
     overwrite: bool = False,
 ):
     """Copy MDIO to MDIO.
+
     Can also copy with empty data to be filled later. See `excludes`
     and `includes` parameters.
 
@@ -87,8 +88,8 @@ def copy(
     in Zarr's documentation in `zarr.convenience.copy_store`.
 
     Args:
-        source: MDIO reader or accessor instance. Data will be copied from here
-        dest_path_or_buffer: Destination path. Could be any FSSpec mapping.
+        input_mdio_path: MDIO reader or accessor instance. Data will be copied from here
+        output_mdio_path: Destination path. Could be any FSSpec mapping.
         excludes: Data to exclude during copy. i.e. `chunked_012`. The raw data
             won't be copied, but it will create an empty array to be filled.
             If left blank, it will copy everything.
@@ -123,7 +124,7 @@ def copy(
     "--output-format",
     required=False,
     default="plain",
-    help="""Output format, plain is human readable.  JSON will output in json 
+    help="""Output format, plain is human readable.  JSON will output in json
     format for easier passing. """,
     type=click.Choice(["plain", "json"]),
     show_default=True,
@@ -167,7 +168,7 @@ def info(
         click.echo("\n\n{:<10} {:<10}".format("STAT", "VALUE"))
         click.echo("=" * 20)
         for name, stat in reader.stats.items():
-            click.echo("{:<10} {:<10}".format(name, stat))
+            click.echo(f"{name:<10} {stat:<10}")
     if output_format == "json":
         mdio_dict["stats"] = reader.stats
         click.echo(mdio_dict)

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -1,11 +1,11 @@
 """Dataset CLI Plugin."""
 
-
 try:
     import click
     import click_params
 
     import mdio
+    from typing import Optional
 except SystemError:
     pass
 
@@ -21,7 +21,7 @@ def cli():
     click.echo("MDIO CLI utilities")
 
 
-@cli.command(name="copy")
+@click.command(name="copy")
 @click.option(
     "-i",
     "--input-mdio-path",
@@ -76,7 +76,7 @@ def copy(
     output_mdio_path: str,
     includes: str = "",
     excludes: str = "",
-    storage_options: dict | None = None,
+    storage_options: Optional[dict] = None,
     overwrite: bool = False,
 ):
     """Copy MDIO to MDIO.
@@ -111,7 +111,7 @@ def copy(
     )
 
 
-@cli.command(name="info")
+@click.command(name="info")
 @click.option(
     "-i",
     "--input-mdio-file",

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -1,11 +1,12 @@
 """Dataset CLI Plugin."""
 
 try:
+    from typing import Optional
+
     import click
     import click_params
 
     import mdio
-    from typing import Optional
 except SystemError:
     pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,13 @@ def zarr_tmp(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def zarr_tmp2(tmp_path_factory):
+    """Make a temp file for the output MDIO."""
+    tmp_file = tmp_path_factory.mktemp(r"mdio2")
+    return tmp_file
+
+
+@pytest.fixture(scope="session")
 def segy_export_ibm_tmp(tmp_path_factory):
     """Make a temp file for the round-trip IBM SEG-Y."""
     tmp_dir = tmp_path_factory.mktemp("segy")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,7 +31,7 @@ def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> No
 @pytest.mark.dependency(depends=["test_main_succeeds"])
 def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["utility", "info"]
+    cli_args = ["info"]
     cli_args.extend(["-i", str(zarr_tmp)])
 
     result = runner.invoke(__main__.main, args=cli_args)
@@ -41,7 +41,7 @@ def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
 @pytest.mark.dependency(depends=["test_main_succeeds"])
 def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["utility", "copy"]
+    cli_args = ["copy"]
     cli_args.extend(["-i", str(zarr_tmp)])
     cli_args.extend(["-o", str(zarr_tmp2)])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,8 +46,7 @@ def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) 
     cli_args.extend(["-o", str(zarr_tmp2)])
 
     result = runner.invoke(__main__.main, args=cli_args)
-    print(f"copy returns {result}")
-    # assert result.exit_code == 0
+    assert result.exit_code == 0
 
 
 def test_cli_version(runner: CliRunner) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.mark.dependency()
 def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
     cli_args = ["segy", "import"]
@@ -25,6 +26,28 @@ def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> No
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0
+
+
+@pytest.mark.dependency(depends=["test_main_succeeds"])
+def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
+    """It exits with a status code of zero."""
+    cli_args = ["utility", "info"]
+    cli_args.extend(["-i", str(zarr_tmp)])
+
+    result = runner.invoke(__main__.main, args=cli_args)
+    assert result.exit_code == 0
+
+
+@pytest.mark.dependency(depends=["test_main_succeeds"])
+def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) -> None:
+    """It exits with a status code of zero."""
+    cli_args = ["utility", "copy"]
+    cli_args.extend(["-i", str(zarr_tmp)])
+    cli_args.extend(["-o", str(zarr_tmp2)])
+
+    result = runner.invoke(__main__.main, args=cli_args)
+    print(f"copy returns {result}")
+    # assert result.exit_code == 0
 
 
 def test_cli_version(runner: CliRunner) -> None:


### PR DESCRIPTION
Resolves #229 and closes #45.  New CLI tools for:
 
mdio utility copy  - this will facilitate users creating new files


mdio utility info  - this will facilitate users get a quick look at the grid metadata and stats for a file
