### PR TITLE
Add QC for SEG-Y ingestion based on trace density.

### DIFF
--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -66,9 +66,12 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
     Args:
         grid: The grid instance to check.
         num_traces: Expected number of traces.
+
+    Raises:
+        GridTraceCountError: When the grid is too sparse.
     """
     grid_traces = np.prod(grid.shape[:-1], dtype=np.uint64)  # Exclude sample
-    dims = {name: shape for name, shape in zip(grid.dim_names, grid.shape)}
+    dims = {k: v for k, v in zip(grid.dim_names, grid.shape)}  # noqa: B905
 
     logger.debug(f"Dimensions: {dims}")
     logger.debug(f"num_traces = {num_traces}")
@@ -84,7 +87,7 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
             f"Grid shape: {grid.shape} but SEG-Y tracecount: {num_traces}. "
             "This grid is very sparse and most likely user error with indexing."
         )
-        raise ValueError(msg)
+        raise GridTraceCountError(msg)
 
     # Warning if we have above 50% sparsity.
     if grid_traces > 2 * num_traces:

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -58,7 +58,7 @@ def parse_index_types(
 def grid_density_qc(grid: Grid, num_traces: int) -> None:
     """QC for sensible Grid density.
 
-    Basic qc of the grid to check density and provide warning/exception 
+    Basic qc of the grid to check density and provide warning/exception
     when indexing is problematic to provide user with insights to the use.
     If trace density on the specified grid is less than 50% a warning is
     logged.  If denisty is less than 1% an exception is raised.
@@ -69,7 +69,7 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
     """
     grid_traces = np.prod(grid.shape[:-1], dtype=np.uint64)  # Exclude sample
     dims = {name: shape for name, shape in zip(grid.dim_names, grid.shape)}
-    
+
     logger.debug(f"Dimensions: {dims}")
     logger.debug(f"num_traces = {num_traces}")
 

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -68,12 +68,13 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
         num_traces: Expected number of traces.
     """
     grid_traces = np.prod(grid.shape[:-1], dtype=np.uint64)  # Exclude sample
-    logger.debug(f"grid.shape = {grid.shape}")
-    logger.debug(f"grid.dim_names = {grid.dim_names}")
+    dims = {name: shape for name, shape in zip(grid.dim_names, grid.shape)}
+    
+    logger.debug(f"Dimensions: {dims}")
     logger.debug(f"num_traces = {num_traces}")
 
     # Extreme case where the grid is very sparse (usually user error)
-    if grid_traces > 100 * num_traces:
+    if grid_traces > 10 * num_traces:
         for dim_name in grid.dim_names:
             dim_min = grid.get_min(dim_name)
             dim_max = grid.get_max(dim_name)
@@ -87,7 +88,6 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
 
     # Warning if we have above 50% sparsity.
     if grid_traces > 2 * num_traces:
-        dims = {name: shape for name, shape in zip(grid.dim_names, grid.shape)}
         msg = (
             f"Proposed ingestion grid is sparse. Ingestion grid: {dims}. "
             f"SEG-Y trace count:{num_traces}, grid trace count: {grid_traces}."


### PR DESCRIPTION
This PR will prevent possible OOM errors due to nonsensical indexing for segy ingestion.  The error will  provide the user with insight on the issue by returning information on the requested grid shape which should inform the user on why the ingestion is problematic.  Th update will produce warnings if the total grid size is greater than two times the number of traces and raise an exception if the trace density on the proposed grid is less than 1%.

