### PR TITLE
Update logic for finding first non-zero sample index in SEG-Y data

### DIFF
--- a/src/mdio/segy/_workers.py
+++ b/src/mdio/segy/_workers.py
@@ -207,7 +207,10 @@ def trace_worker(
         value=tmp_metadata,
     )
 
-    nonzero_z = tmp_data.sum(axis=tuple(range(n_dim - 1))).nonzero()
+    # Find first non-zero index in sample (last) dimension
+    non_sample_axes = tuple(range(n_dim - 1))
+    nonzero_z = np.where(np.any(tmp_data != 0, axis=non_sample_axes))
+
     if len(nonzero_z[0]) == 0:
         return
 


### PR DESCRIPTION
The previous `np.sum()` based method to get non-zero indexes in multidimensional SEG-Y data was replaced with the `np.where()` method. This new approach directly checks where in the data non-zero elements exist, which provides a more accurate result, especially in cases of complex top mute. The sum was underflowing to zero in some cases where the values were too small.