### PR TITLE
Add sparsity check override

### DIFF
--- a/src/mdio/converters/exceptions.py
+++ b/src/mdio/converters/exceptions.py
@@ -15,3 +15,16 @@ class GridTraceCountError(Exception):
         )
 
         super().__init__(self.message)
+
+
+class GridTraceSparsityError(Exception):
+    """Raised when mdio grid will be sparsely populated from SEG-Y traces."""
+
+    def __init__(self, shape, num_traces):
+        """Initialize error."""
+        self.message = (
+            f"Grid shape: {shape} but SEG-Y tracecount: {num_traces}. "
+            "This grid is very sparse and most likely user error with indexing."
+        )
+
+        super().__init__(self.message)

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -61,14 +61,16 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
     Basic qc of the grid to check density and provide warning/exception
     when indexing is problematic to provide user with insights to the use.
     If trace density on the specified grid is less than 50% a warning is
-    logged.  If denisty is less than 1% an exception is raised.
+    logged.  If density is less than 10% an exception is raised. To ignore
+    trace sparsity check set environment variable:
+        MDIO_IGNORE_CHECKS = True
 
     Args:
         grid: The grid instance to check.
         num_traces: Expected number of traces.
 
     Raises:
-        GridTraceCountError: When the grid is too sparse.
+        GridTraceSparsityError: When the grid is too sparse.
     """
     grid_traces = np.prod(grid.shape[:-1], dtype=np.uint64)  # Exclude sample
     dims = {k: v for k, v in zip(grid.dim_names, grid.shape)}  # noqa: B905


### PR DESCRIPTION
Enable sparsity check to be ignored. When environment variable:
MDIO_IGNORE_CHECKS=True
Exception for sparse grids is ignore.  This can lead to poor performance so should be used with care.

Resolves #284 