### PR TITLE
Fix RtD index page links and update documentation links and naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Conda](https://img.shields.io/conda/vn/conda-forge/multidimio)][install_conda]
 [![Python Version](https://img.shields.io/pypi/pyversions/multidimio)][python version]
 [![Status](https://img.shields.io/pypi/status/multidimio.svg)][status]
-[![License](https://img.shields.io/pypi/l/multidimio)][license]
+[![License](https://img.shields.io/pypi/l/multidimio)][apache 2.0 license]
 
 [![Tests](https://github.com/TGSAI/mdio-python/workflows/Tests/badge.svg)][tests]
 [![Codecov](https://codecov.io/gh/TGSAI/mdio-python/branch/main/graph/badge.svg)][codecov]
@@ -83,14 +83,14 @@ $ conda install -c conda-forge multidimio
 
 > Extras must be installed separately on `Conda` environments.
 
-For details, please see the [installation instructions][install]
+For details, please see the [installation instructions]
 in the documentation.
 
 # Using MDIO
 
-Please see the [Command-line Reference][usage] for details.
+Please see the [Command-line Usage] for details.
 
-For Python API please see the [API Reference][reference] for details.
+For Python API please see the [API Reference] for details.
 
 # Requirements
 
@@ -113,7 +113,7 @@ To learn more, see the [Contributor Guide].
 
 # Licensing
 
-Distributed under the terms of the [Apache 2.0 license][license],
+Distributed under the terms of the [Apache 2.0 license],
 _MDIO_ is free and open source software.
 
 # Issues
@@ -151,8 +151,8 @@ template.
 
 <!-- github-only -->
 
-[license]: https://github.com/TGSAI/mdio-python/blob/main/LICENSE
+[apache 2.0 license]: https://github.com/TGSAI/mdio-python/blob/main/LICENSE
 [contributor guide]: https://github.com/TGSAI/mdio-python/blob/main/CONTRIBUTING.md
-[usage]: https://mdio-python.readthedocs.io/en/latest/usage.html
-[reference]: https://mdio-python.readthedocs.io/en/latest/reference.html
-[install]: https://mdio-python.readthedocs.io/en/latest/installation.html
+[command-line usage]: https://mdio-python.readthedocs.io/en/latest/usage.html
+[api reference]: https://mdio-python.readthedocs.io/en/latest/reference.html
+[installation instructions]: https://mdio-python.readthedocs.io/en/latest/installation.html

--- a/README.md
+++ b/README.md
@@ -123,10 +123,9 @@ please [file an issue] along with a detailed description.
 
 # Credits
 
-This project was established at [TGS](https://www.tgs.com/). Original authors
-and current maintainers are [Altay Sansal](https://github.com/tasansal) and
-[Sri Kainkaryam](https://github.com/srib); with the support of many more great
-colleagues.
+This project was established at [TGS](https://www.tgs.com/). Current maintainer is
+[Altay Sansal](https://github.com/tasansal) with the support of
+many more great colleagues.
 
 This project template is based on [@cjolowicz]'s [Hypermodern Python Cookiecutter]
 template.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,11 @@ end-before: <!-- github-only -->
 ---
 ```
 
-[license]: license
+[apache 2.0 license]: license
 [contributor guide]: contributing
-[command-line reference]: usage
+[command-line usage]: usage
+[api reference]: reference
+[installation instructions]: installation
 
 ```{toctree}
 ---

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -33,6 +33,7 @@ and
 ```{eval-rst}
 .. automodule:: mdio.converters.segy
    :members:
+   :exclude-members: grid_density_qc, parse_index_types
 
 .. automodule:: mdio.converters.mdio
    :members:


### PR DESCRIPTION
Updated documentation links and clarified naming conventions in index.md and README.md. Changed the reference to the license from the generic term [license] to [Apache 2.0 license]. Additionally, the [command-line reference] has been renamed to [Command-line Usage], and [API Reference] was added for clarity. These changes improve the user's understanding of the content and ensure that the information is accurately linked.