### PR TITLE
New CLI Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ mdio1/*
 */mdio1/*
 pytest-of-*
 tmp
+debugging/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 pip-*
-*pytest*
 tmp*
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -152,4 +151,4 @@ cython_debug/
 mdio1/*
 */mdio1/*
 pytest-of-*
-tmp/
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
+pip-*
+*pytest*
+tmp*
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,8 +9,8 @@ There are many more options, please see the [CLI Reference](#cli-reference).
 
 ```shell
 $ mdio segy import \
-    -i path_to_segy_file.segy \
-    -o path_to_mdio_file.mdio \
+    path_to_segy_file.segy \
+    path_to_mdio_file.mdio \
     -loc 181,185 \
     -names inline,crossline
 ```
@@ -20,8 +20,8 @@ should be executed.
 
 ```shell
 $ mdio segy export \
-    -i path_to_mdio_file.mdio \
-    -o path_to_segy_file.segy
+    path_to_mdio_file.mdio \
+    path_to_segy_file.segy
 ```
 
 ## Cloud Connection Strings
@@ -79,9 +79,9 @@ Using UNIX:
 
 ```shell
 mdio segy import \
-  --input-segy-path path/to/my.segy
-  --output-mdio-file s3://bucket/prefix/my.mdio
-  --header-locations 189,193
+  path/to/my.segy \
+  s3://bucket/prefix/my.mdio \
+  --header-locations 189,193 \
   --storage-options '{"key": "my_super_private_key", "secret": "my_super_private_secret"}'
 ```
 
@@ -89,9 +89,9 @@ Using Windows (note the extra escape characters `\`):
 
 ```console
 mdio segy import \
-  --input-segy-path path/to/my.segy
-  --output-mdio-file s3://bucket/prefix/my.mdio
-  --header-locations 189,193
+  path/to/my.segy \
+  s3://bucket/prefix/my.mdio \
+  --header-locations 189,193 \
   --storage-options "{\"key\": \"my_super_private_key\", \"secret\": \"my_super_private_secret\"}"
 ```
 
@@ -114,9 +114,9 @@ Using a service account:
 
 ```shell
 mdio segy import \
-  --input-segy-path path/to/my.segy
-  --output-mdio-file gs://bucket/prefix/my.mdio
-  --header-locations 189,193
+  path/to/my.segy \
+  gs://bucket/prefix/my.mdio \
+  --header-locations 189,193 \
   --storage-options '{"token": "~/.config/gcloud/application_default_credentials.json"}'
 ```
 
@@ -124,9 +124,9 @@ Using browser to populate authentication:
 
 ```shell
 mdio segy import \
-  --input-segy-path path/to/my.segy
-  --output-mdio-file gs://bucket/prefix/my.mdio
-  --header-locations 189,193
+  path/to/my.segy \
+  gs://bucket/prefix/my.mdio \
+  --header-locations 189,193 \
   --storage-options '{"token": "browser"}'
 ```
 
@@ -145,9 +145,9 @@ If ADL is not pre-authenticated, you need to pass `--storage-options`.
 
 ```shell
 mdio segy import \
-  --input-segy-path path/to/my.segy
-  --output-mdio-file az://bucket/prefix/my.mdio
-  --header-locations 189,193
+  path/to/my.segy \
+  az://bucket/prefix/my.mdio \
+  --header-locations 189,193 \
   --storage-options '{"account_name": "myaccount", "account_key": "my_super_private_key"}'
 ```
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -132,6 +132,7 @@ def precommit(session: Session) -> None:
         "pre-commit",
         "pre-commit-hooks",
         "pyupgrade",
+        "pytest-dependency",
     )
     session.run("pre-commit", *args)
     if args and args[0] == "install":

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,6 @@
 """Nox sessions."""
+
+
 import os
 import shlex
 import shutil
@@ -132,7 +134,6 @@ def precommit(session: Session) -> None:
         "pre-commit",
         "pre-commit-hooks",
         "pyupgrade",
-        "pytest-dependency",
     )
     session.run("pre-commit", *args)
     if args and args[0] == "install":
@@ -162,7 +163,7 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments")
+    session.install("coverage[toml]", "pytest", "pygments", "pytest-dependency")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3922,4 +3922,4 @@ lossy = ["zfpy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "f37f8958d33532310f30f24a74c0d6be902a0c12a86a0c755e455154eb938d13"
+content-hash = "17b5182f23ab5c113220e3883f5a4ae591d92fa1b669a25387c4b7ec8a17409f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ segyio = "^1.9.3"
 numba = "^0.59.0"
 psutil = "^5.9.5"
 fsspec = ">=2023.9.1"
+rich = "^13.7.1"
 urllib3 = "^1.26.18" # Workaround for poetry-plugin-export/issues/183
 
 # Extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,5 @@ ignore_missing_imports = true
 
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core", "fastentrypoints"]
 build-backend = "poetry.core.masonry.api"

--- a/src/mdio/__main__.py
+++ b/src/mdio/__main__.py
@@ -11,9 +11,9 @@ from typing import Callable
 import click
 
 
-KNOWN_MODULES = ["segy.py"]
 KNOWN_MODULES = [
     "segy.py",
+    "copy.py",
     "info.py",
 ]
 

--- a/src/mdio/__main__.py
+++ b/src/mdio/__main__.py
@@ -12,14 +12,20 @@ import click
 
 
 KNOWN_MODULES = ["segy.py"]
+KNOWN_MODULES = [
+    "segy.py",
+    "info.py",
+]
 
 
 class MyCLI(click.MultiCommand):
     """CLI generator via plugin design pattern.
 
     This class dynamically loads command modules from the specified
-    `plugin_folder`. Each command module should define a `cli` function
-    that implements the command logic.
+    `plugin_folder`. If the command us another CLI group, the command
+    module must define a `cli = click.Group(...)` and subsequent
+    commands must be added to this CLI. If it is a single utility it
+    must have a variable named `cli` for the command to be exposed.
 
     Args:
     - plugin_folder: Path to the directory containing command modules.

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-import click_params
 from click import BOOL
 from click import STRING
 from click import argument
 from click import command
 from click import option
+from click_params import JSON
 
 
 @command(name="copy")
@@ -48,7 +48,7 @@ from click import option
     "--storage-options",
     required=False,
     help="Custom storage options for cloud backends",
-    type=click_params.JSON,
+    type=JSON,
 )
 @option(
     "-overwrite",
@@ -67,7 +67,7 @@ def copy(
     excludes: str = "",
     storage_options: dict | None = None,
     overwrite: bool = False,
-):
+) -> None:
     """Copy a MDIO dataset to anpther MDIO dataset.
 
     Can also copy with empty data to be filled later. See `excludes`

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -10,20 +10,8 @@ import mdio
 
 
 @click.command(name="copy")
-@click.option(
-    "-i",
-    "--input-mdio-path",
-    required=True,
-    help="Input mdio path.",
-    type=click.Path(exists=True),
-)
-@click.option(
-    "-o",
-    "--output-mdio-path",
-    required=True,
-    help="Output path or URL to write the mdio dataset.",
-    type=click.STRING,
-)
+@click.argument("source-mdio-path", type=str)
+@click.argument("target-mdio-path", type=str)
 @click.option(
     "-access",
     "--access-pattern",
@@ -71,8 +59,8 @@ import mdio
     show_default=True,
 )
 def copy(
-    input_mdio_path: str,
-    output_mdio_path: str,
+    source_mdio_path: str,
+    target_mdio_path: str,
     access_pattern: str = "012",
     includes: str = "",
     excludes: str = "",
@@ -88,11 +76,11 @@ def copy(
     in Zarr's documentation in `zarr.convenience.copy_store`.
     """
     reader = mdio.MDIOReader(
-        input_mdio_path, access_pattern=access_pattern, return_metadata=True
+        source_mdio_path, access_pattern=access_pattern, return_metadata=True
     )
     mdio.copy_mdio(
         source=reader,
-        dest_path_or_buffer=output_mdio_path,
+        dest_path_or_buffer=target_mdio_path,
         excludes=excludes,
         includes=includes,
         storage_options=storage_options,

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -1,14 +1,12 @@
-"""Dataset CLI Plugin."""
+"""MDIO Dataset copy command."""
 
-try:
-    from typing import Optional
 
-    import click
-    import click_params
+from typing import Optional
 
-    import mdio
-except SystemError:
-    pass
+import click
+import click_params
+
+import mdio
 
 
 @click.command(name="copy")
@@ -102,76 +100,4 @@ def copy(
     )
 
 
-@click.command(name="info")
-@click.option(
-    "-i",
-    "--input-mdio-file",
-    required=True,
-    help="Input path of the mdio file",
-    type=click.STRING,
-)
-@click.option(
-    "-access",
-    "--access-pattern",
-    required=False,
-    default="012",
-    help="Access pattern of the file",
-    type=click.STRING,
-    show_default=True,
-)
-@click.option(
-    "-format",
-    "--output-format",
-    required=False,
-    default="plain",
-    help="""Output format, plain is human readable.  JSON will output in json
-    format for easier passing. """,
-    type=click.Choice(["plain", "json"]),
-    show_default=True,
-    show_choices=True,
-)
-def info(
-    input_mdio_file,
-    output_format,
-    access_pattern,
-):
-    """Provide information on a MDIO dataset.
-
-    By default this returns human readable information about the grid and stats for
-    the dataset. If output-format is set to json then a json is returned to
-    facilitate parsing.
-    """
-    reader = mdio.MDIOReader(
-        input_mdio_file, access_pattern=access_pattern, return_metadata=True
-    )
-    mdio_dict = {}
-    mdio_dict["grid"] = {}
-    for axis in reader.grid.dim_names:
-        dim = reader.grid.select_dim(axis)
-        min = dim.coords[0]
-        max = dim.coords[-1]
-        size = dim.coords.shape[0]
-        axis_dict = {"name": axis, "min": min, "max": max, "size": size}
-        mdio_dict["grid"][axis] = axis_dict
-
-    if output_format == "plain":
-        click.echo("{:<10} {:<10} {:<10} {:<10}".format("NAME", "MIN", "MAX", "SIZE"))
-        click.echo("=" * 40)
-
-        for _, axis_dict in mdio_dict["grid"].items():
-            click.echo(
-                "{:<10} {:<10} {:<10} {:<10}".format(
-                    axis_dict["name"],
-                    axis_dict["min"],
-                    axis_dict["max"],
-                    axis_dict["size"],
-                )
-            )
-
-        click.echo("\n\n{:<10} {:<10}".format("STAT", "VALUE"))
-        click.echo("=" * 20)
-        for name, stat in reader.stats.items():
-            click.echo(f"{name:<10} {stat:<10}")
-    if output_format == "json":
-        mdio_dict["stats"] = reader.stats
-        click.echo(mdio_dict)
+cli = copy

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from click import BOOL
 from click import STRING
 from click import argument
 from click import command
@@ -53,10 +52,8 @@ from click_params import JSON
 @option(
     "-overwrite",
     "--overwrite",
-    required=False,
-    default=False,
-    help="Flag to overwrite if MDIO file exists",
-    type=BOOL,
+    is_flag=True,
+    help="Flag to overwrite if mdio file if it exists",
     show_default=True,
 )
 def copy(

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -1,6 +1,8 @@
 """MDIO Dataset copy command."""
 
 
+from __future__ import annotations
+
 import click_params
 from click import BOOL
 from click import STRING

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -10,8 +10,6 @@ from click import argument
 from click import command
 from click import option
 
-from mdio import MDIOReader
-
 
 @command(name="copy")
 @argument("source-mdio-path", type=str)
@@ -78,6 +76,8 @@ def copy(
     More documentation about `excludes` and `includes` can be found
     in Zarr's documentation in `zarr.convenience.copy_store`.
     """
+    from mdio import MDIOReader
+
     reader = MDIOReader(source_mdio_path, access_pattern=access_pattern)
 
     reader.copy(

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -1,61 +1,62 @@
 """MDIO Dataset copy command."""
 
 
-from typing import Optional
-
-import click
 import click_params
+from click import BOOL
+from click import STRING
+from click import argument
+from click import command
+from click import option
 
-import mdio
+from mdio import MDIOReader
 
 
-@click.command(name="copy")
-@click.argument("source-mdio-path", type=str)
-@click.argument("target-mdio-path", type=str)
-@click.option(
+@command(name="copy")
+@argument("source-mdio-path", type=str)
+@argument("target-mdio-path", type=str)
+@option(
     "-access",
     "--access-pattern",
     required=False,
     default="012",
     help="Access pattern of the file",
-    type=click.STRING,
+    type=STRING,
     show_default=True,
 )
-@click.option(
+@option(
     "-exc",
     "--excludes",
     required=False,
     default="",
-    help="""Data to exclude during copy. i.e. chunked_012. The raw data won’t be
-    copied, but it will create an empty array to be filled. If left blank, it will
-    copy everything.""",
-    type=click.STRING,
+    help="Data to exclude during copy, like `chunked_012`. The data values won’t be "
+    "copied but an empty array will be created. If blank, it copies everything.",
+    type=STRING,
 )
-@click.option(
+@option(
     "-inc",
     "--includes",
     required=False,
     default="",
-    help="""Data to include during copy. i.e. trace_headers. If this is not
-    specified, and certain data is excluded, it will not copy headers. To
-    preserve headers, specify trace_headers. If left blank, it will copy
-    everything except specified in excludes parameter.""",
-    type=click.STRING,
+    help="Data to include during copy, like `trace_headers`. If not specified, and "
+    "certain data is excluded, it will not copy headers. To preserve headers, "
+    "specify trace_headers. If left blank, it will copy everything except what is "
+    "specified in the 'excludes' parameter.",
+    type=STRING,
 )
-@click.option(
+@option(
     "-storage",
     "--storage-options",
     required=False,
     help="Custom storage options for cloud backends",
     type=click_params.JSON,
 )
-@click.option(
+@option(
     "-overwrite",
     "--overwrite",
     required=False,
     default=False,
-    help="Flag to overwrite if mdio file if it exists",
-    type=click.BOOL,
+    help="Flag to overwrite if MDIO file exists",
+    type=BOOL,
     show_default=True,
 )
 def copy(
@@ -64,7 +65,7 @@ def copy(
     access_pattern: str = "012",
     includes: str = "",
     excludes: str = "",
-    storage_options: Optional[dict] = None,
+    storage_options: dict | None = None,
     overwrite: bool = False,
 ):
     """Copy a MDIO dataset to anpther MDIO dataset.
@@ -75,11 +76,9 @@ def copy(
     More documentation about `excludes` and `includes` can be found
     in Zarr's documentation in `zarr.convenience.copy_store`.
     """
-    reader = mdio.MDIOReader(
-        source_mdio_path, access_pattern=access_pattern, return_metadata=True
-    )
-    mdio.copy_mdio(
-        source=reader,
+    reader = MDIOReader(source_mdio_path, access_pattern=access_pattern)
+
+    reader.copy(
         dest_path_or_buffer=target_mdio_path,
         excludes=excludes,
         includes=includes,

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -36,7 +36,7 @@ from mdio import MDIOReader
     show_choices=True,
 )
 def info(
-    input_mdio_file: str,
+    mdio_path: str,
     output_format: str,
     access_pattern: str,
 ) -> None:
@@ -47,7 +47,7 @@ def info(
     facilitate parsing.
     """
     reader = MDIOReader(
-        input_mdio_file,
+        mdio_path,
         access_pattern=access_pattern,
         return_metadata=True,
     )
@@ -83,7 +83,7 @@ def info(
         for stat, value in reader.stats.items():
             stat_table.add_row(stat, f"{value:.4f}")
 
-        master_table = Table()
+        master_table = Table(title=f"File Information for {mdio_path}")
         master_table.add_column("MDIO Grid", justify="center")
         master_table.add_column("MDIO Statistics", justify="center")
         master_table.add_row(grid_table, stat_table)

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -1,6 +1,8 @@
 """MDIO Dataset information command."""
 
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -76,7 +78,7 @@ def cast_stats(stats_dict: dict[str, Any]) -> dict[str, float]:
     return {k: float(v) for k, v in stats_dict.items()}
 
 
-def parse_grid(grid: "Grid") -> dict[str, dict[str, int | str]]:
+def parse_grid(grid: Grid) -> dict[str, dict[str, int | str]]:
     """Extract grid information per dimension."""
     grid_dict = {}
     for dim_name in grid.dim_names:

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -1,0 +1,105 @@
+"""Dataset CLI Plugin."""
+
+
+from json import dumps as json_dumps
+
+from click import Choice
+from click import command
+from click import option
+from rich import print
+from rich.console import Console
+from rich.table import Table
+
+from mdio import MDIOReader
+
+
+@command(name="info")
+@option(
+    "-i",
+    "--input-mdio-file",
+    required=True,
+    help="Input path of the mdio file",
+    type=str,
+)
+@option(
+    "-access",
+    "--access-pattern",
+    required=False,
+    default="012",
+    help="Access pattern of the file",
+    type=str,
+    show_default=True,
+)
+@option(
+    "-format",
+    "--output-format",
+    required=False,
+    default="plain",
+    help="Output format. Pretty console or JSON.",
+    type=Choice(["pretty", "json"]),
+    show_default=True,
+    show_choices=True,
+)
+def info(
+    input_mdio_file: str,
+    output_format: str,
+    access_pattern: str,
+) -> None:
+    """Provide information on a MDIO dataset.
+
+    By default, this returns human-readable information about the grid and stats for
+    the dataset. If output-format is set to json then a json is returned to
+    facilitate parsing.
+    """
+    reader = MDIOReader(
+        input_mdio_file,
+        access_pattern=access_pattern,
+        return_metadata=True,
+    )
+
+    mdio_dict = {}
+    mdio_dict["grid"] = {}
+
+    for dim_name in reader.grid.dim_names:
+        dim = reader.grid.select_dim(dim_name)
+        min_ = str(dim.coords[0])
+        max_ = str(dim.coords[-1])
+        size = str(dim.coords.shape[0])
+        axis_dict = {"name": dim_name, "min": min_, "max": max_, "size": size}
+        mdio_dict["grid"][dim_name] = axis_dict
+
+    if output_format == "pretty":
+        console = Console()
+
+        grid_table = Table(show_edge=False)
+        grid_table.add_column("Dimension", justify="right", style="cyan", no_wrap=True)
+        grid_table.add_column("Min", justify="left", style="magenta")
+        grid_table.add_column("Max", justify="left", style="magenta")
+        grid_table.add_column("Size", justify="left", style="green")
+
+        for _, axis_dict in mdio_dict["grid"].items():
+            name, min_, max_, size = axis_dict.values()
+            grid_table.add_row(name, min_, max_, size)
+
+        stat_table = Table(show_edge=False)
+        stat_table.add_column("Stat", justify="right", style="cyan", no_wrap=True)
+        stat_table.add_column("Value", justify="left", style="magenta")
+
+        for stat, value in reader.stats.items():
+            stat_table.add_row(stat, f"{value:.4f}")
+
+        master_table = Table()
+        master_table.add_column("MDIO Grid", justify="center")
+        master_table.add_column("MDIO Statistics", justify="center")
+        master_table.add_row(grid_table, stat_table)
+
+        console.print(master_table)
+
+    if output_format == "json":
+        stats_cast = {k: float(v) for k, v in reader.stats.items()}
+        mdio_dict["stats"] = stats_cast
+
+        print(json_dumps(mdio_dict, indent=2))
+
+
+cli = info

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -1,18 +1,18 @@
 """MDIO Dataset information command."""
 
 
-from json import dumps as json_dumps
+from typing import TYPE_CHECKING
+from typing import Any
 
 from click import STRING
 from click import Choice
 from click import argument
 from click import command
 from click import option
-from rich import print
-from rich.console import Console
-from rich.table import Table
 
-from mdio import MDIOReader
+
+if TYPE_CHECKING:
+    from mdio.core import Grid
 
 
 @command(name="info")
@@ -47,55 +47,86 @@ def info(
     the dataset. If output-format is set to json then a json is returned to
     facilitate parsing.
     """
+    from mdio import MDIOReader
+
     reader = MDIOReader(
         mdio_path,
         access_pattern=access_pattern,
         return_metadata=True,
     )
 
-    mdio_dict = {}
-    mdio_dict["grid"] = {}
+    grid_dict = parse_grid(reader.grid)
+    stats_dict = cast_stats(reader.stats)
 
-    for dim_name in reader.grid.dim_names:
-        dim = reader.grid.select_dim(dim_name)
+    mdio_info = {
+        "path": mdio_path,
+        "stats": stats_dict,
+        "grid": grid_dict,
+    }
+
+    if output_format == "pretty":
+        pretty_print(mdio_info)
+
+    if output_format == "json":
+        json_print(mdio_info)
+
+
+def cast_stats(stats_dict: dict[str, Any]) -> dict[str, float]:
+    """Normalize all floats to JSON serializable floats."""
+    return {k: float(v) for k, v in stats_dict.items()}
+
+
+def parse_grid(grid: "Grid") -> dict[str, dict[str, int | str]]:
+    """Extract grid information per dimension."""
+    grid_dict = {}
+    for dim_name in grid.dim_names:
+        dim = grid.select_dim(dim_name)
         min_ = str(dim.coords[0])
         max_ = str(dim.coords[-1])
         size = str(dim.coords.shape[0])
-        axis_dict = {"name": dim_name, "min": min_, "max": max_, "size": size}
-        mdio_dict["grid"][dim_name] = axis_dict
+        grid_dict[dim_name] = {"name": dim_name, "min": min_, "max": max_, "size": size}
+    return grid_dict
 
-    if output_format == "pretty":
-        console = Console()
 
-        grid_table = Table(show_edge=False)
-        grid_table.add_column("Dimension", justify="right", style="cyan", no_wrap=True)
-        grid_table.add_column("Min", justify="left", style="magenta")
-        grid_table.add_column("Max", justify="left", style="magenta")
-        grid_table.add_column("Size", justify="left", style="green")
+def json_print(mdio_info: dict[str, Any]) -> None:
+    """Convert MDIO Info to JSON and pretty print."""
+    from json import dumps as json_dumps
 
-        for _, axis_dict in mdio_dict["grid"].items():
-            name, min_, max_, size = axis_dict.values()
-            grid_table.add_row(name, min_, max_, size)
+    from rich import print
 
-        stat_table = Table(show_edge=False)
-        stat_table.add_column("Stat", justify="right", style="cyan", no_wrap=True)
-        stat_table.add_column("Value", justify="left", style="magenta")
+    print(json_dumps(mdio_info, indent=2))
 
-        for stat, value in reader.stats.items():
-            stat_table.add_row(stat, f"{value:.4f}")
 
-        master_table = Table(title=f"File Information for {mdio_path}")
-        master_table.add_column("MDIO Grid", justify="center")
-        master_table.add_column("MDIO Statistics", justify="center")
-        master_table.add_row(grid_table, stat_table)
+def pretty_print(mdio_info: dict[str, Any]) -> None:
+    """Print pretty MDIO Info table to console."""
+    from rich.console import Console
+    from rich.table import Table
 
-        console.print(master_table)
+    console = Console()
 
-    if output_format == "json":
-        stats_cast = {k: float(v) for k, v in reader.stats.items()}
-        mdio_dict["stats"] = stats_cast
+    grid_table = Table(show_edge=False)
+    grid_table.add_column("Dimension", justify="right", style="cyan", no_wrap=True)
+    grid_table.add_column("Min", justify="left", style="magenta")
+    grid_table.add_column("Max", justify="left", style="magenta")
+    grid_table.add_column("Size", justify="left", style="green")
 
-        print(json_dumps(mdio_dict, indent=2))
+    for _, axis_dict in mdio_info["grid"].items():
+        name, min_, max_, size = axis_dict.values()
+        grid_table.add_row(name, min_, max_, size)
+
+    stat_table = Table(show_edge=False)
+    stat_table.add_column("Stat", justify="right", style="cyan", no_wrap=True)
+    stat_table.add_column("Value", justify="left", style="magenta")
+
+    for stat, value in mdio_info["stats"].items():
+        stat_table.add_row(stat, f"{value:.4f}")
+
+    master_table = Table(title=f"File Information for {mdio_info['path']}")
+    master_table.add_column("MDIO Grid", justify="center")
+    master_table.add_column("MDIO Statistics", justify="center")
+    master_table.add_row(grid_table, stat_table)
+
+    console.print(master_table)
 
 
 cli = info

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -3,6 +3,7 @@
 
 from json import dumps as json_dumps
 
+from click import STRING
 from click import Choice
 from click import argument
 from click import command
@@ -15,14 +16,14 @@ from mdio import MDIOReader
 
 
 @command(name="info")
-@argument("mdio-path", type=str)
+@argument("mdio-path", type=STRING)
 @option(
     "-access",
     "--access-pattern",
     required=False,
     default="012",
     help="Access pattern of the file",
-    type=str,
+    type=STRING,
     show_default=True,
 )
 @option(

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -4,6 +4,7 @@
 from json import dumps as json_dumps
 
 from click import Choice
+from click import argument
 from click import command
 from click import option
 from rich import print
@@ -14,13 +15,7 @@ from mdio import MDIOReader
 
 
 @command(name="info")
-@option(
-    "-i",
-    "--input-mdio-file",
-    required=True,
-    help="Input path of the mdio file",
-    type=str,
-)
+@argument("mdio-path", type=str)
 @option(
     "-access",
     "--access-pattern",
@@ -34,7 +29,7 @@ from mdio import MDIOReader
     "-format",
     "--output-format",
     required=False,
-    default="plain",
+    default="pretty",
     help="Output format. Pretty console or JSON.",
     type=Choice(["pretty", "json"]),
     show_default=True,

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -1,4 +1,4 @@
-"""Dataset CLI Plugin."""
+"""MDIO Dataset information command."""
 
 
 from json import dumps as json_dumps

--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -1,13 +1,10 @@
 """SEG-Y Import/Export CLI Plugin."""
 
 
-try:
-    import click
-    import click_params
+import click
+import click_params
 
-    import mdio
-except SystemError:
-    pass
+import mdio
 
 
 SEGY_HELP = """

--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -3,7 +3,6 @@
 
 from typing import Any
 
-import click_params
 from click import BOOL
 from click import FLOAT
 from click import STRING
@@ -12,6 +11,9 @@ from click import Group
 from click import Path
 from click import argument
 from click import option
+from click_params import JSON
+from click_params import IntListParamType
+from click_params import StringListParamType
 
 
 SEGY_HELP = """
@@ -72,28 +74,28 @@ cli = Group(name="segy", help=SEGY_HELP)
     "--header-locations",
     required=True,
     help="Byte locations of the index attributes in SEG-Y trace header.",
-    type=click_params.IntListParamType(),
+    type=IntListParamType(),
 )
 @option(
     "-types",
     "--header-types",
     required=False,
     help="Data types of the index attributes in SEG-Y trace header.",
-    type=click_params.StringListParamType(),
+    type=StringListParamType(),
 )
 @option(
     "-names",
     "--header-names",
     required=False,
     help="Names of the index attributes",
-    type=click_params.StringListParamType(),
+    type=StringListParamType(),
 )
 @option(
     "-chunks",
     "--chunk-size",
     required=False,
     help="Custom chunk size for bricked storage",
-    type=click_params.IntListParamType(),
+    type=IntListParamType(),
 )
 @option(
     "-endian",
@@ -128,7 +130,7 @@ cli = Group(name="segy", help=SEGY_HELP)
     "--storage-options",
     required=False,
     help="Custom storage options for cloud backends",
-    type=click_params.JSON,
+    type=JSON,
 )
 @option(
     "-overwrite",
@@ -144,7 +146,7 @@ cli = Group(name="segy", help=SEGY_HELP)
     "--grid-overrides",
     required=False,
     help="Option to add grid overrides.",
-    type=click_params.JSON,
+    type=JSON,
 )
 def segy_import(
     segy_path: str,
@@ -393,7 +395,7 @@ def segy_import(
     "--storage-options",
     required=False,
     help="Custom storage options for cloud backends.",
-    type=click_params.JSON,
+    type=JSON,
 )
 @option(
     "-endian",

--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -1,10 +1,17 @@
 """SEG-Y Import/Export CLI Plugin."""
 
 
-import click
-import click_params
+from typing import Any
 
-import mdio
+import click_params
+from click import BOOL
+from click import FLOAT
+from click import STRING
+from click import Choice
+from click import Group
+from click import Path
+from click import argument
+from click import option
 
 
 SEGY_HELP = """
@@ -54,97 +61,85 @@ locations for indexing. However, the headers are stored as the SEG-Y Rev 1
 after ingestion.
 """
 
-cli = click.Group(name="segy", help=SEGY_HELP)
+cli = Group(name="segy", help=SEGY_HELP)
 
 
 @cli.command(name="import")
-@click.option(
-    "-i",
-    "--input-segy-path",
-    required=True,
-    help="Input SEG-Y file path.",
-    type=click.Path(exists=True),
-)
-@click.option(
-    "-o",
-    "--output-mdio-file",
-    required=True,
-    help="Output path or URL to write the mdio file.",
-    type=click.STRING,
-)
-@click.option(
+@argument("segy-path", type=Path(exists=True))
+@argument("mdio-path", type=STRING)
+@option(
     "-loc",
     "--header-locations",
     required=True,
     help="Byte locations of the index attributes in SEG-Y trace header.",
     type=click_params.IntListParamType(),
 )
-@click.option(
+@option(
     "-types",
     "--header-types",
     required=False,
     help="Data types of the index attributes in SEG-Y trace header.",
     type=click_params.StringListParamType(),
 )
-@click.option(
+@option(
     "-names",
     "--header-names",
     required=False,
     help="Names of the index attributes",
     type=click_params.StringListParamType(),
 )
-@click.option(
+@option(
     "-chunks",
     "--chunk-size",
     required=False,
     help="Custom chunk size for bricked storage",
     type=click_params.IntListParamType(),
 )
-@click.option(
+@option(
     "-endian",
     "--endian",
     required=False,
     default="big",
     help="Endianness of the SEG-Y file",
-    type=click.Choice(["little", "big"]),
+    type=Choice(["little", "big"]),
     show_default=True,
     show_choices=True,
 )
-@click.option(
+@option(
     "-lossless",
     "--lossless",
     required=False,
     default=True,
     help="Toggle lossless, and perceptually lossless compression",
-    type=click.BOOL,
+    type=BOOL,
     show_default=True,
 )
-@click.option(
+@option(
     "-tolerance",
     "--compression-tolerance",
     required=False,
     default=0.01,
     help="Lossy compression tolerance in ZFP.",
-    type=click.FLOAT,
+    type=FLOAT,
     show_default=True,
 )
-@click.option(
+@option(
     "-storage",
     "--storage-options",
     required=False,
     help="Custom storage options for cloud backends",
     type=click_params.JSON,
 )
-@click.option(
+@option(
     "-overwrite",
     "--overwrite",
     required=False,
     default=False,
     help="Flag to overwrite if mdio file if it exists",
-    type=click.BOOL,
+    type=BOOL,
     show_default=True,
 )
-@click.option(
+@option(
     "-grid-overrides",
     "--grid-overrides",
     required=False,
@@ -152,18 +147,18 @@ cli = click.Group(name="segy", help=SEGY_HELP)
     type=click_params.JSON,
 )
 def segy_import(
-    input_segy_path,
-    output_mdio_file,
-    header_locations,
-    header_types,
-    header_names,
-    chunk_size,
-    endian,
-    lossless,
-    compression_tolerance,
-    storage_options,
-    overwrite,
-    grid_overrides,
+    segy_path: str,
+    mdio_path: str,
+    header_locations: list[int],
+    header_types: list[str],
+    header_names: list[str],
+    chunk_size: list[int],
+    endian: str,
+    lossless: bool,
+    compression_tolerance: float,
+    storage_options: dict[str, Any],
+    overwrite: bool,
+    grid_overrides: dict[str, Any],
 ):
     """Ingest SEG-Y file to MDIO.
 
@@ -353,9 +348,11 @@ def segy_import(
         --chunk-size 8,2,256,512
         --grid-overrides '{"HasDuplicates": True}'
     """
-    mdio.segy_to_mdio(
-        segy_path=input_segy_path,
-        mdio_path_or_buffer=output_mdio_file,
+    from mdio import segy_to_mdio
+
+    segy_to_mdio(
+        segy_path=segy_path,
+        mdio_path_or_buffer=mdio_path,
         index_bytes=header_locations,
         index_types=header_types,
         index_names=header_names,
@@ -370,63 +367,51 @@ def segy_import(
 
 
 @cli.command(name="export")
-@click.option(
-    "-i",
-    "--input-mdio-file",
-    required=True,
-    help="Input path of the mdio file",
-    type=click.STRING,
-)
-@click.option(
-    "-o",
-    "--output-segy-path",
-    required=True,
-    help="Output SEG-Y file",
-    type=click.Path(exists=False),
-)
-@click.option(
+@argument("mdio-file", type=STRING)
+@argument("segy-path", type=Path(exists=False))
+@option(
     "-access",
     "--access-pattern",
     required=False,
     default="012",
     help="Access pattern of the file",
-    type=click.STRING,
+    type=STRING,
     show_default=True,
 )
-@click.option(
+@option(
     "-format",
     "--segy-format",
     required=False,
     default="ibm32",
     help="SEG-Y sample format",
-    type=click.Choice(["ibm32", "ieee32"]),
+    type=Choice(["ibm32", "ieee32"]),
     show_default=True,
     show_choices=True,
 )
-@click.option(
+@option(
     "-storage",
     "--storage-options",
     required=False,
     help="Custom storage options for cloud backends.",
     type=click_params.JSON,
 )
-@click.option(
+@option(
     "-endian",
     "--endian",
     required=False,
     default="big",
     help="Endianness of the SEG-Y file",
-    type=click.Choice(["little", "big"]),
+    type=Choice(["little", "big"]),
     show_default=True,
     show_choices=True,
 )
 def segy_export(
-    input_mdio_file,
-    output_segy_path,
-    access_pattern,
-    segy_format,
-    storage_options,
-    endian,
+    mdio_file: str,
+    segy_path: str,
+    access_pattern: str,
+    segy_format: str,
+    storage_options: dict[str, Any],
+    endian: str,
 ):
     """Export MDIO file to SEG-Y.
 
@@ -448,9 +433,11 @@ def segy_export(
     The input MDIO can be local or cloud based. However, the output SEG-Y
     will be generated locally.
     """
-    mdio.mdio_to_segy(
-        mdio_path_or_buffer=input_mdio_file,
-        output_segy_path=output_segy_path,
+    from mdio import mdio_to_segy
+
+    mdio_to_segy(
+        mdio_path_or_buffer=mdio_file,
+        output_segy_path=segy_path,
         access_pattern=access_pattern,
         out_sample_format=segy_format,
         storage_options=storage_options,

--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -135,10 +135,8 @@ cli = Group(name="segy", help=SEGY_HELP)
 @option(
     "-overwrite",
     "--overwrite",
-    required=False,
-    default=False,
+    is_flag=True,
     help="Flag to overwrite if mdio file if it exists",
-    type=BOOL,
     show_default=True,
 )
 @option(

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -27,9 +27,19 @@ except SystemError:
     type=click.STRING,
 )
 @click.option(
+    "-access",
+    "--access-pattern",
+    required=False,
+    default="012",
+    help="Access pattern of the file",
+    type=click.STRING,
+    show_default=True,
+)
+@click.option(
     "-exc",
     "--excludes",
     required=False,
+    default="",
     help="""Data to exclude during copy. i.e. chunked_012. The raw data won’t be
     copied, but it will create an empty array to be filled. If left blank, it will
     copy everything.""",
@@ -39,6 +49,7 @@ except SystemError:
     "-inc",
     "--includes",
     required=False,
+    default="",
     help="""Data to include during copy. i.e. trace_headers. If this is not
     specified, and certain data is excluded, it will not copy headers. To
     preserve headers, specify trace_headers. If left blank, it will copy
@@ -62,8 +73,9 @@ except SystemError:
     show_default=True,
 )
 def copy(
-    input_mdio_path,
+    input_mdio_path: str,
     output_mdio_path: str,
+    access_pattern: str = "012",
     includes: str = "",
     excludes: str = "",
     storage_options: Optional[dict] = None,
@@ -77,8 +89,11 @@ def copy(
     More documentation about `excludes` and `includes` can be found
     in Zarr's documentation in `zarr.convenience.copy_store`.
     """
+    reader = mdio.MDIOReader(
+        input_mdio_path, access_pattern=access_pattern, return_metadata=True
+    )
     mdio.copy_mdio(
-        source=input_mdio_path,
+        source=reader,
         dest_path_or_buffer=output_mdio_path,
         excludes=excludes,
         includes=includes,

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -1,0 +1,167 @@
+"""Dataset CLI Plugin."""
+
+
+try:
+    import click
+    import click_params
+
+    import mdio
+    import json
+except SystemError:
+    pass
+
+
+DEFAULT_HELP = """
+MDIO CLI utilities. 
+"""
+
+
+@click.group(help=DEFAULT_HELP)
+def cli():
+    click.echo(f"MDIO CLI utilities")
+
+
+@cli.command(name="copy")
+@click.option(
+    "-i",
+    "--input-mdio-path",
+    required=True,
+    help="Input mdio path.",
+    type=click.Path(exists=True),
+)
+@click.option(
+    "-o",
+    "--output-mdio-path",
+    required=True,
+    help="Output path or URL to write the mdio dataset.",
+    type=click.STRING,
+)
+@click.option(
+    "-exc",
+    "--excludes",
+    required=False,
+    help="Data to exclude during copy. i.e. chunked_012. The raw data won’t be copied, but it will create an empty array to be filled. If left blank, it will copy everything.",
+    type=click.STRING,
+)
+@click.option(
+    "-inc",
+    "--includes",
+    required=False,
+    help="Data to include during copy. i.e. trace_headers. If this is not specified, and certain data is excluded, it will not copy headers. If you want to preserve headers, specify trace_headers. If left blank, it will copy everything except specified in excludes parameter.",
+    type=click.STRING,
+)
+@click.option(
+    "-storage",
+    "--storage-options",
+    required=False,
+    help="Custom storage options for cloud backends",
+    type=click_params.JSON,
+)
+@click.option(
+    "-overwrite",
+    "--overwrite",
+    required=False,
+    default=False,
+    help="Flag to overwrite if mdio file if it exists",
+    type=click.BOOL,
+    show_default=True,
+)
+def copy(
+    input_mdio_path,
+    output_mdio_path: str,
+    includes: str = "",
+    excludes: str = "",
+    storage_options: dict | None = None,
+    overwrite: bool = False,
+):
+    """Copy MDIO to MDIO.
+    Can also copy with empty data to be filled later. See `excludes`
+    and `includes` parameters.
+
+    More documentation about `excludes` and `includes` can be found
+    in Zarr's documentation in `zarr.convenience.copy_store`.
+
+    Args:
+        source: MDIO reader or accessor instance. Data will be copied from here
+        dest_path_or_buffer: Destination path. Could be any FSSpec mapping.
+        excludes: Data to exclude during copy. i.e. `chunked_012`. The raw data
+            won't be copied, but it will create an empty array to be filled.
+            If left blank, it will copy everything.
+        includes: Data to include during copy. i.e. `trace_headers`. If this is
+            not specified, and certain data is excluded, it will not copy headers.
+            If you want to preserve headers, specify `trace_headers`. If left blank,
+            it will copy everything except specified in `excludes` parameter.
+        storage_options: Storage options for the cloud storage backend.
+            Default is None (will assume anonymous).
+        overwrite: Overwrite destination or not.
+    """
+    mdio.copy_mdio(
+        source=input_mdio_path,
+        dest_path_or_buffer=output_mdio_path,
+        excludes=excludes,
+        includes=includes,
+        storage_options=storage_options,
+        overwrite=overwrite,
+    )
+
+
+@cli.command(name="info")
+@click.option(
+    "-i",
+    "--input-mdio-file",
+    required=True,
+    help="Input path of the mdio file",
+    type=click.STRING,
+)
+@click.option(
+    "-format",
+    "--output-format",
+    required=False,
+    default="plain",
+    help="Output format, plain is human readable.  JSON will output in json format for easier passing. ",
+    type=click.Choice(["plain", "json"]),
+    show_default=True,
+    show_choices=True,
+)
+def info(
+    input_mdio_file,
+    output_format,
+):
+    """Provide information on MDIO dataset.
+
+    By default this returns human readable information about the grid and stats for the dataset. If output-format is set to json then a json is returned to facilitate parsing
+
+
+    """
+    reader = mdio.MDIOReader(input_mdio_file, return_metadata=True)
+    mdio_dict = {}
+    mdio_dict["grid"] = {}
+    for axis in reader.grid.dim_names:
+        dim = reader.grid.select_dim(axis)
+        min = dim.coords[0]
+        max = dim.coords[-1]
+        size = dim.coords.shape[0]
+        axis_dict = {"name": axis, "min": min, "max": max, "size": size}
+        mdio_dict["grid"][axis] = axis_dict
+
+    if output_format == "plain":
+        click.echo("{:<10} {:<10} {:<10} {:<10}".format("NAME", "MIN", "MAX", "SIZE"))
+        click.echo("=" * 40)
+
+        for _, axis_dict in mdio_dict["grid"].items():
+            click.echo(
+                "{:<10} {:<10} {:<10} {:<10}".format(
+                    axis_dict["name"],
+                    axis_dict["min"],
+                    axis_dict["max"],
+                    axis_dict["size"],
+                )
+            )
+
+        click.echo("\n\n{:<10} {:<10}".format("STAT", "VALUE"))
+        click.echo("=" * 20)
+        for name, stat in reader.stats.items():
+            click.echo("{:<10} {:<10}".format(name, stat))
+    if output_format == "json":
+        mdio_dict["stats"] = reader.stats
+        click.echo(mdio_dict)

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -40,14 +40,19 @@ def cli():
     "-exc",
     "--excludes",
     required=False,
-    help="Data to exclude during copy. i.e. chunked_012. The raw data won’t be copied, but it will create an empty array to be filled. If left blank, it will copy everything.",
+    help="""Data to exclude during copy. i.e. chunked_012. The raw data won’t be
+    copied, but it will create an empty array to be filled. If left blank, it will
+    copy everything.""",
     type=click.STRING,
 )
 @click.option(
     "-inc",
     "--includes",
     required=False,
-    help="Data to include during copy. i.e. trace_headers. If this is not specified, and certain data is excluded, it will not copy headers. If you want to preserve headers, specify trace_headers. If left blank, it will copy everything except specified in excludes parameter.",
+    help="""Data to include during copy. i.e. trace_headers. If this is not 
+    specified, and certain data is excluded, it will not copy headers. If you want
+    to preserve headers, specify trace_headers. If left blank, it will copy
+    everything except specified in excludes parameter.""",
     type=click.STRING,
 )
 @click.option(
@@ -118,7 +123,8 @@ def copy(
     "--output-format",
     required=False,
     default="plain",
-    help="Output format, plain is human readable.  JSON will output in json format for easier passing. ",
+    help="""Output format, plain is human readable.  JSON will output in json 
+    format for easier passing. """,
     type=click.Choice(["plain", "json"]),
     show_default=True,
     show_choices=True,
@@ -129,9 +135,9 @@ def info(
 ):
     """Provide information on MDIO dataset.
 
-    By default this returns human readable information about the grid and stats for the dataset. If output-format is set to json then a json is returned to facilitate parsing
-
-
+    By default this returns human readable information about the grid and stats for
+    the dataset. If output-format is set to json then a json is returned to
+    facilitate parsing.
     """
     reader = mdio.MDIOReader(input_mdio_file, return_metadata=True)
     mdio_dict = {}

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -120,6 +120,15 @@ def copy(
     type=click.STRING,
 )
 @click.option(
+    "-access",
+    "--access-pattern",
+    required=False,
+    default="012",
+    help="Access pattern of the file",
+    type=click.STRING,
+    show_default=True,
+)
+@click.option(
     "-format",
     "--output-format",
     required=False,
@@ -133,6 +142,7 @@ def copy(
 def info(
     input_mdio_file,
     output_format,
+    access_pattern,
 ):
     """Provide information on MDIO dataset.
 
@@ -140,7 +150,9 @@ def info(
     the dataset. If output-format is set to json then a json is returned to
     facilitate parsing.
     """
-    reader = mdio.MDIOReader(input_mdio_file, return_metadata=True)
+    reader = mdio.MDIOReader(
+        input_mdio_file, access_pattern=access_pattern, return_metadata=True
+    )
     mdio_dict = {}
     mdio_dict["grid"] = {}
     for axis in reader.grid.dim_names:

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -11,17 +11,6 @@ except SystemError:
     pass
 
 
-DEFAULT_HELP = """
-MDIO CLI utilities.
-"""
-
-
-@click.group(help=DEFAULT_HELP)
-def cli():
-    """Setup click group."""
-    click.echo("MDIO CLI utilities")
-
-
 @click.command(name="copy")
 @click.option(
     "-i",
@@ -51,8 +40,8 @@ def cli():
     "--includes",
     required=False,
     help="""Data to include during copy. i.e. trace_headers. If this is not
-    specified, and certain data is excluded, it will not copy headers. If you want
-    to preserve headers, specify trace_headers. If left blank, it will copy
+    specified, and certain data is excluded, it will not copy headers. To
+    preserve headers, specify trace_headers. If left blank, it will copy
     everything except specified in excludes parameter.""",
     type=click.STRING,
 )
@@ -80,27 +69,13 @@ def copy(
     storage_options: Optional[dict] = None,
     overwrite: bool = False,
 ):
-    """Copy MDIO to MDIO.
+    """Copy a MDIO dataset to anpther MDIO dataset.
 
     Can also copy with empty data to be filled later. See `excludes`
     and `includes` parameters.
 
     More documentation about `excludes` and `includes` can be found
     in Zarr's documentation in `zarr.convenience.copy_store`.
-
-    Args:
-        input_mdio_path: MDIO reader or accessor instance. Data will be copied from here
-        output_mdio_path: Destination path. Could be any FSSpec mapping.
-        excludes: Data to exclude during copy. i.e. `chunked_012`. The raw data
-            won't be copied, but it will create an empty array to be filled.
-            If left blank, it will copy everything.
-        includes: Data to include during copy. i.e. `trace_headers`. If this is
-            not specified, and certain data is excluded, it will not copy headers.
-            If you want to preserve headers, specify `trace_headers`. If left blank,
-            it will copy everything except specified in `excludes` parameter.
-        storage_options: Storage options for the cloud storage backend.
-            Default is None (will assume anonymous).
-        overwrite: Overwrite destination or not.
     """
     mdio.copy_mdio(
         source=input_mdio_path,
@@ -145,7 +120,7 @@ def info(
     output_format,
     access_pattern,
 ):
-    """Provide information on MDIO dataset.
+    """Provide information on a MDIO dataset.
 
     By default this returns human readable information about the grid and stats for
     the dataset. If output-format is set to json then a json is returned to

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -6,19 +6,19 @@ try:
     import click_params
 
     import mdio
-    import json
 except SystemError:
     pass
 
 
 DEFAULT_HELP = """
-MDIO CLI utilities. 
+MDIO CLI utilities.
 """
 
 
 @click.group(help=DEFAULT_HELP)
 def cli():
-    click.echo(f"MDIO CLI utilities")
+    """Setup click group."""
+    click.echo("MDIO CLI utilities")
 
 
 @cli.command(name="copy")
@@ -49,7 +49,7 @@ def cli():
     "-inc",
     "--includes",
     required=False,
-    help="""Data to include during copy. i.e. trace_headers. If this is not 
+    help="""Data to include during copy. i.e. trace_headers. If this is not
     specified, and certain data is excluded, it will not copy headers. If you want
     to preserve headers, specify trace_headers. If left blank, it will copy
     everything except specified in excludes parameter.""",
@@ -80,6 +80,7 @@ def copy(
     overwrite: bool = False,
 ):
     """Copy MDIO to MDIO.
+
     Can also copy with empty data to be filled later. See `excludes`
     and `includes` parameters.
 
@@ -87,8 +88,8 @@ def copy(
     in Zarr's documentation in `zarr.convenience.copy_store`.
 
     Args:
-        source: MDIO reader or accessor instance. Data will be copied from here
-        dest_path_or_buffer: Destination path. Could be any FSSpec mapping.
+        input_mdio_path: MDIO reader or accessor instance. Data will be copied from here
+        output_mdio_path: Destination path. Could be any FSSpec mapping.
         excludes: Data to exclude during copy. i.e. `chunked_012`. The raw data
             won't be copied, but it will create an empty array to be filled.
             If left blank, it will copy everything.
@@ -123,7 +124,7 @@ def copy(
     "--output-format",
     required=False,
     default="plain",
-    help="""Output format, plain is human readable.  JSON will output in json 
+    help="""Output format, plain is human readable.  JSON will output in json
     format for easier passing. """,
     type=click.Choice(["plain", "json"]),
     show_default=True,
@@ -167,7 +168,7 @@ def info(
         click.echo("\n\n{:<10} {:<10}".format("STAT", "VALUE"))
         click.echo("=" * 20)
         for name, stat in reader.stats.items():
-            click.echo("{:<10} {:<10}".format(name, stat))
+            click.echo(f"{name:<10} {stat:<10}")
     if output_format == "json":
         mdio_dict["stats"] = reader.stats
         click.echo(mdio_dict)

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -1,11 +1,11 @@
 """Dataset CLI Plugin."""
 
-
 try:
     import click
     import click_params
 
     import mdio
+    from typing import Optional
 except SystemError:
     pass
 
@@ -21,7 +21,7 @@ def cli():
     click.echo("MDIO CLI utilities")
 
 
-@cli.command(name="copy")
+@click.command(name="copy")
 @click.option(
     "-i",
     "--input-mdio-path",
@@ -76,7 +76,7 @@ def copy(
     output_mdio_path: str,
     includes: str = "",
     excludes: str = "",
-    storage_options: dict | None = None,
+    storage_options: Optional[dict] = None,
     overwrite: bool = False,
 ):
     """Copy MDIO to MDIO.
@@ -111,7 +111,7 @@ def copy(
     )
 
 
-@cli.command(name="info")
+@click.command(name="info")
 @click.option(
     "-i",
     "--input-mdio-file",

--- a/src/mdio/commands/utility.py
+++ b/src/mdio/commands/utility.py
@@ -1,11 +1,12 @@
 """Dataset CLI Plugin."""
 
 try:
+    from typing import Optional
+
     import click
     import click_params
 
     import mdio
-    from typing import Optional
 except SystemError:
     pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,13 @@ def zarr_tmp(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def zarr_tmp2(tmp_path_factory):
+    """Make a temp file for the output MDIO."""
+    tmp_file = tmp_path_factory.mktemp(r"mdio2")
+    return tmp_file
+
+
+@pytest.fixture(scope="session")
 def segy_export_ibm_tmp(tmp_path_factory):
     """Make a temp file for the round-trip IBM SEG-Y."""
     tmp_dir = tmp_path_factory.mktemp("segy")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,9 +18,7 @@ def runner() -> CliRunner:
 @pytest.mark.dependency()
 def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["segy", "import"]
-    cli_args.extend(["-i", segy_input])
-    cli_args.extend(["-o", str(zarr_tmp)])
+    cli_args = ["segy", "import", segy_input, str(zarr_tmp)]
     cli_args.extend(["-loc", "181,185"])
     cli_args.extend(["-names", "inline,crossline"])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,7 +31,7 @@ def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> No
 @pytest.mark.dependency(depends=["test_main_succeeds"])
 def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["utility", "info"]
+    cli_args = ["info"]
     cli_args.extend(["-i", str(zarr_tmp)])
 
     result = runner.invoke(__main__.main, args=cli_args)
@@ -41,7 +41,7 @@ def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
 @pytest.mark.dependency(depends=["test_main_succeeds"])
 def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["utility", "copy"]
+    cli_args = ["copy"]
     cli_args.extend(["-i", str(zarr_tmp)])
     cli_args.extend(["-o", str(zarr_tmp2)])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,8 +46,7 @@ def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) 
     cli_args.extend(["-o", str(zarr_tmp2)])
 
     result = runner.invoke(__main__.main, args=cli_args)
-    print(f"copy returns {result}")
-    # assert result.exit_code == 0
+    assert result.exit_code == 0
 
 
 def test_cli_version(runner: CliRunner) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from mdio import __main__
 
 
-@pytest.fixture
+@pytest.fixture()
 def runner() -> CliRunner:
     """Fixture for invoking command-line interfaces."""
     return CliRunner()
@@ -32,7 +32,7 @@ def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> No
 def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
     cli_args = ["info"]
-    cli_args.extend(["-i", str(zarr_tmp)])
+    cli_args.extend([str(zarr_tmp)])
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.mark.dependency()
 def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
     cli_args = ["segy", "import"]
@@ -25,6 +26,28 @@ def test_main_succeeds(runner: CliRunner, segy_input: str, zarr_tmp: Path) -> No
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0
+
+
+@pytest.mark.dependency(depends=["test_main_succeeds"])
+def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
+    """It exits with a status code of zero."""
+    cli_args = ["utility", "info"]
+    cli_args.extend(["-i", str(zarr_tmp)])
+
+    result = runner.invoke(__main__.main, args=cli_args)
+    assert result.exit_code == 0
+
+
+@pytest.mark.dependency(depends=["test_main_succeeds"])
+def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) -> None:
+    """It exits with a status code of zero."""
+    cli_args = ["utility", "copy"]
+    cli_args.extend(["-i", str(zarr_tmp)])
+    cli_args.extend(["-o", str(zarr_tmp2)])
+
+    result = runner.invoke(__main__.main, args=cli_args)
+    print(f"copy returns {result}")
+    # assert result.exit_code == 0
 
 
 def test_cli_version(runner: CliRunner) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,9 +41,7 @@ def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
 @pytest.mark.dependency(depends=["test_main_succeeds"])
 def test_main_copy_succeeds(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["copy"]
-    cli_args.extend(["-i", str(zarr_tmp)])
-    cli_args.extend(["-o", str(zarr_tmp2)])
+    cli_args = ["copy", str(zarr_tmp), str(zarr_tmp2)]
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0


### PR DESCRIPTION
Continues #230 

Had to refactor due to recent CLI changes in `main`. Also added the following to @markspec's work:

1. Rich printing support 
2. Refactored `info` command to components
3. Refactored arguments and options for all CLI
4. Lazy imports and added `fastentrypoints` **[CLI much faster now]**
5. Made required parameters arguments instead of options (I/o files etc) **[BREAKING]**
6. Changed `overwrite` to flag **[BREAKING]**
7. Update tests accordingly
8. Update docs accordingly