### PR TITLE
Allow import/export completely custom SEG-Y via spec override environment variable

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3442,24 +3442,24 @@ python-versions = ">=3.6"
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
@@ -3467,7 +3467,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
@@ -3475,7 +3475,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
@@ -3483,7 +3483,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
@@ -3567,13 +3567,13 @@ typing-extensions = ">=4.7.1"
 
 [[package]]
 name = "segy"
-version = "0.2.0"
+version = "0.2.2"
 description = "The Ultimate Python SEG-Y I/O with Cloud Support and Schemas"
 optional = false
 python-versions = "<3.13,>=3.9"
 files = [
-    {file = "segy-0.2.0-py3-none-any.whl", hash = "sha256:f7b52ed9a90cf6c2673694a7bec8185a6bab7f558db4aa32401f4ea9db326022"},
-    {file = "segy-0.2.0.tar.gz", hash = "sha256:f27778dfb7f6d51f9d150e631e0df6ca0ff0a0292034870811b069b59aef5a58"},
+    {file = "segy-0.2.2-py3-none-any.whl", hash = "sha256:1de7bc49cb2d29aa6ca708c897fa38561c7e508464654f61d05faa20bdc224e8"},
+    {file = "segy-0.2.2.tar.gz", hash = "sha256:584a8e1bce56d056175feb56e45d6d8cba080dd9cc7a610a023de5bf359585b3"},
 ]
 
 [package.dependencies]
@@ -4646,4 +4646,4 @@ lossy = ["zfpy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "4c9d04c0c1f0bf4d623ad518083cc6d5820593f16789e6ab11c43efb129e4710"
+content-hash = "15639e6dcd5aba74e11cd32ba490188ba9aa6c784b395dfccf18d27ec1691d81"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dask = ">=2024.6.1"
 tqdm = "^4.66.4"
 psutil = "^6.0.0"
 fsspec = ">=2024.9.0"
-segy = "^0.2.0"
+segy = "^0.2.2"
 rich = "^13.7.1"
 urllib3 = "^1.26.18" # Workaround for poetry-plugin-export/issues/183
 

--- a/src/mdio/segy/compat.py
+++ b/src/mdio/segy/compat.py
@@ -17,7 +17,6 @@ from segy.schema import HeaderField
 from segy.schema import HeaderSpec
 from segy.schema import ScalarType
 from segy.schema import SegySpec
-from segy.schema import TextHeaderEncoding
 from segy.schema import TextHeaderSpec
 from segy.schema import TraceDataSpec
 from segy.schema import TraceSpec
@@ -59,7 +58,10 @@ def get_trace_fields(version: str) -> list[HeaderField]:
 
 def mdio_segy_spec(version: str | None = None) -> SegySpec:
     """Get a SEG-Y encoding spec for MDIO based on version."""
-    encoding = os.getenv("MDIO__SEGY__TEXT_ENCODING", TextHeaderEncoding.EBCDIC)
+    spec_override = os.getenv("MDIO__SEGY__SPEC")
+
+    if spec_override is not None:
+        return SegySpec.model_validate_json(spec_override)
 
     version = MDIO_VERSION if version is None else version
 
@@ -68,7 +70,7 @@ def mdio_segy_spec(version: str | None = None) -> SegySpec:
 
     return SegySpec(
         segy_standard=None,
-        text_header=TextHeaderSpec(encoding=encoding),
+        text_header=TextHeaderSpec(),
         binary_header=HeaderSpec(fields=binary_fields, item_size=400, offset=3200),
         trace=TraceSpec(
             header=HeaderSpec(fields=trace_fields, item_size=240),

--- a/src/mdio/segy/compat.py
+++ b/src/mdio/segy/compat.py
@@ -8,6 +8,7 @@ This is where we define it.
 
 from __future__ import annotations
 
+import os
 from importlib import metadata
 
 from segy.alias.segyio import SEGYIO_BIN_FIELD_MAP
@@ -16,6 +17,7 @@ from segy.schema import HeaderField
 from segy.schema import HeaderSpec
 from segy.schema import ScalarType
 from segy.schema import SegySpec
+from segy.schema import TextHeaderEncoding
 from segy.schema import TextHeaderSpec
 from segy.schema import TraceDataSpec
 from segy.schema import TraceSpec
@@ -57,6 +59,8 @@ def get_trace_fields(version: str) -> list[HeaderField]:
 
 def mdio_segy_spec(version: str | None = None) -> SegySpec:
     """Get a SEG-Y encoding spec for MDIO based on version."""
+    encoding = os.getenv("MDIO__SEGY__TEXT_ENCODING", TextHeaderEncoding.EBCDIC)
+
     version = MDIO_VERSION if version is None else version
 
     binary_fields = get_binary_fields()
@@ -64,7 +68,7 @@ def mdio_segy_spec(version: str | None = None) -> SegySpec:
 
     return SegySpec(
         segy_standard=None,
-        text_header=TextHeaderSpec(),  # default EBCDIC
+        text_header=TextHeaderSpec(encoding=encoding),
         binary_header=HeaderSpec(fields=binary_fields, item_size=400, offset=3200),
         trace=TraceSpec(
             header=HeaderSpec(fields=trace_fields, item_size=240),


### PR DESCRIPTION
There are some edge cases (i.e. custom header definitions out of spec) when default MDIO SEG-Y spec doesn't unpack some values into JSON and if it is exported, the data will be lost. 

In those cases we can give a full SEG-Y spec based on the [`TGSAI/segy`](https://github.com/TGSAI/segy) schema as a JSON environment variable: `MDIO__SEGY__SPEC`. 

As long as the user has the JSON available at runtime; MDIO should be able to ingest/export files conforming to that spec.

IMPORTANT: Re-emphasizing that the files ingested with a custom JSON spec will ONLY be exportable if the spec is available. Or else default MDIO can't export it since it will be out of spec.