### PR TITLE
New "Cloud Native" mode for ingesting remote files from a cloud environment

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,7 +162,32 @@ Some useful examples are:
 - File Buffering and random access
 - Mount anything with FUSE
 
-````{note}
+#### Buffered Reads in Ingestion
+
+MDIO v0.8.2 introduces the `MDIO__IMPORT__CLOUD_NATIVE` environment variable to optimize
+SEG-Y header scans by balancing bandwidth usage with read latency through buffered reads.
+
+**When to Use:** This variable is most effective in high-throughput environments like cloud-based ingestion
+systems but can also improve performance for mechanical drives or slow connections.
+
+**How to Enable:** Set the variable to `{"True", "1", "true"}`. For example:
+
+```console
+$ export MDIO__IMPORT__CLOUD_NATIVE="true"
+```
+
+**How It Works:** Buffered reads minimize millions of remote requests during SEG-Y header scans:
+
+- **Cloud Environments:** Ideal for high-throughput connections between cloud ingestion
+  machines and object stores.
+- **Slow Connections:** Bandwidth is the bottleneck, may be faster without it.
+- **Local Reads:** May benefit mechanical drives; SSDs typically perform fine without it.
+
+While buffered reads process the file twice, the tradeoff improves ingestion performance and
+reduces object-store request costs.
+
+#### Chaining `fsspec` Protocols
+
 When combining advanced protocols like `simplecache` and using a remote store like `s3` the
 URL can be chained like `simplecache::s3://bucket/prefix/file.mdio`. When doing this the
 `--storage-options` argument must explicitly state parameters for the cloud backend and the
@@ -181,10 +206,10 @@ extra protocol. For the above example it would look like this:
 ```
 
 In one line:
+
 ```json
 {"s3": {"key": "my_super_private_key", "secret": "my_super_private_secret"}, "simplecache": {"cache_storage": "/custom/temp/storage/path"}
 ```
-````
 
 ## CLI Reference
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -170,7 +170,7 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments", "pytest-dependency")
+    session.install("coverage[toml]", "pytest", "pygments", "pytest-dependency", "s3fs")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -66,7 +66,7 @@ cli = Group(name="segy", help=SEGY_HELP)
 
 
 @cli.command(name="import")
-@argument("segy-path", type=Path(exists=True))
+@argument("segy-path", type=STRING)
 @argument("mdio-path", type=STRING)
 @option(
     "-loc",

--- a/src/mdio/segy/_workers.py
+++ b/src/mdio/segy/_workers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -37,7 +38,14 @@ def header_scan_worker(
     Returns:
         HeaderArray parsed from SEG-Y library.
     """
-    return segy_file.header[slice(*trace_range)]
+    slice_ = slice(*trace_range)
+
+    cloud_native_mode = os.getenv("MDIO__IMPORT__CLOUD_NATIVE", default="False")
+
+    if cloud_native_mode.lower() in {"true", "1"}:
+        return segy_file.trace[slice_].header
+
+    return segy_file.header[slice_]
 
 
 def trace_worker(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,17 @@ def fake_segy_tmp(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def segy_input(tmp_path_factory):
+def segy_input_uri():
+    """Path to dome dataset for cloud testing."""
+    return "http://s3.amazonaws.com/teapot/filt_mig.sgy"
+
+
+@pytest.fixture(scope="session")
+def segy_input(segy_input_uri, tmp_path_factory):
     """Download teapot dome dataset for testing."""
-    url = "http://s3.amazonaws.com/teapot/filt_mig.sgy"
     tmp_dir = tmp_path_factory.mktemp("segy")
     tmp_file = path.join(tmp_dir, "teapot.segy")
-    urlretrieve(url, tmp_file)  # noqa: S310
+    urlretrieve(segy_input_uri, tmp_file)  # noqa: S310
 
     return tmp_file
 


### PR DESCRIPTION
### Summary 
A new environment variable called `MDIO__IMPORT__CLOUD_NATIVE` trades off available bandwidth against random read latency. Added to documentation as well.

**It is only helpful in a high-speed throughput environment, such as data and ingestion machine(s) in the cloud.**

Values that will enable it are `{"True", "1", "true"}`. For instance:

```console
$ export MDIO__IMPORT__CLOUD_NATIVE="true"
```

### Details
When we scan the headers of a remote SEG-Y file, the ideal case is to read ONLY headers for each trace to minimize bandwidth requirements. However, this causes millions of requests, a performance bottleneck even with multiprocessing or threading. If the client has a very slow internet connection, this will still be okay. When reading local files from SSD, this is fine; mechanical drives may still be problematic and benefit from the flag.

This `MDIO__IMPORT__CLOUD_NATIVE` flag enables buffered reading of the file regardless of where the ingestion occurs. If the file is on the cloud, and ingestion machine(s) are on the cloud with high-throughput between machine(s) and object store, this flag works very well. The only disadvantage is it reads the file twice (just like any other buffered read). However, this tradeoff significantly increases the ingestion performance on a cloud-native environment and at a lower cost (fewer requests to the object).