### PR TITLE
Fix crash in header parsing when trace count is parsing `block_size` + 1

### DIFF
--- a/src/mdio/segy/_workers.py
+++ b/src/mdio/segy/_workers.py
@@ -55,9 +55,9 @@ def header_scan_worker(
 
     # Copy to non-padded memory, ndmin is to handle the case where there is
     # 1 trace in block (singleton) so we can concat and assign stuff later.
-    trace_header_filtered = np.array(trace_header, dtype=new_dtype, ndmin=1)
+    trace_header = np.array(trace_header, dtype=new_dtype, ndmin=1)
 
-    return cast(HeaderArray, trace_header_filtered)
+    return cast(HeaderArray, trace_header)
 
 
 def trace_worker(

--- a/src/mdio/segy/_workers.py
+++ b/src/mdio/segy/_workers.py
@@ -53,9 +53,9 @@ def header_scan_worker(
     non_void_fields = [(name, dtype) for name, (dtype, _) in fields.items()]
     new_dtype = np.dtype(non_void_fields)
 
-    # Allocate empty memory and assign non-void fields
-    trace_header_filtered = np.empty_like(trace_header, dtype=new_dtype)
-    trace_header_filtered[:] = trace_header
+    # Copy to non-padded memory, ndmin is to handle the case where there is
+    # 1 trace in block (singleton) so we can concat and assign stuff later.
+    trace_header_filtered = np.array(trace_header, dtype=new_dtype, ndmin=1)
 
     return cast(HeaderArray, trace_header_filtered)
 


### PR DESCRIPTION
# Problem

There was an edge case when the trace count was 1 more than the N*block_size for parsing the grid headers; this caused a singleton array to return.

E.g. if the block size is 100 and we have 201 traces, blocks:
1. [0, 100) = array size 100
2. [100, 200) = array size 100
3. [200, 201) = array size 1 (singleton)

In the third block, this caused unexpected indexing and subsequent concatenation errors due to us manipulating a singleton array with slicing semantics.

# Solution

Ensure the new filtered array is at least 1d by using `ndmin=1` in array constructor.