### PR TITLE
Optimize new SEG-Y export logic

### DIFF
--- a/src/mdio/segy/blocked_io.py
+++ b/src/mdio/segy/blocked_io.py
@@ -215,11 +215,11 @@ def segy_trace_concat(
     if np.count_nonzero(is_block_live) == 0:
         return is_block_live.any(axis=-1)
 
-    result_chunk_shape = block_info[None]["chunk-shape"]
+    block_shape = is_block_live.shape
     block_coords = block_info[0]["array-location"]
 
     prefix_block_coords = block_coords[:consecutive_dim_index]
-    prefix_block_shape = result_chunk_shape[:consecutive_dim_index]
+    prefix_block_shape = block_shape[:consecutive_dim_index]
 
     # Generate iterators for dimension's index and coords
     indices_iter = np.ndindex(prefix_block_shape)

--- a/src/mdio/segy/blocked_io.py
+++ b/src/mdio/segy/blocked_io.py
@@ -225,6 +225,7 @@ def segy_trace_concat(
     indices_iter = np.ndindex(prefix_block_shape)
     coords_iter = ndrange(prefix_block_coords)
 
+    destination_map = {}
     for dim_indices, dim_coords in zip(indices_iter, coords_iter, strict=True):
         # TODO(Altay): When python minimum is 3.11 change to is_block_live[*dim_indices]
         aligned_live = is_block_live[tuple(dim_indices)]
@@ -232,16 +233,22 @@ def segy_trace_concat(
         if np.count_nonzero(aligned_live) == 0:
             continue
 
-        source_file_index = ".".join(map(str, dim_coords))
-        source_path = f"{filename_prefix}/{source_file_index}._mdiotemp"
+        source_index = "/".join(map(str, dim_coords))
+        dest_index = "/".join(map(str, dim_coords[:-1]))
 
-        dest_file_index = ".".join(map(str, dim_coords[:-1]))
-        dest_path = f"{filename_prefix}/{dest_file_index}._mdiotemp"
+        if dest_index not in destination_map:
+            destination_map[dest_index] = []
 
-        with open(dest_path, "ab") as dest, open(source_path, "rb") as src:
-            copyfileobj(src, dest)
+        destination_map[dest_index].append(source_index)
 
-        os.remove(source_path)
+    for dest_index, source_indices in destination_map.items():
+        dest_path = f"{filename_prefix}/{dest_index}._mdiotemp"
+        with open(dest_path, "wb") as dest_file:
+            for src_index in source_indices:
+                src_path = f"{filename_prefix}/{src_index}._mdiotemp"
+                with open(src_path, "rb") as src_file:
+                    copyfileobj(src_file, dest_file)
+                os.remove(src_path)
 
     return is_block_live.any(axis=-1)
 

--- a/src/mdio/segy/creation.py
+++ b/src/mdio/segy/creation.py
@@ -175,8 +175,11 @@ def serialize_to_segy_stack(
         aligned_headers = headers[tuple(dim_indices)][aligned_live_mask]
 
         buffer = segy_factory.create_traces(aligned_headers, aligned_samples)
-        aligned_filename = ".".join(map(str, dim_coords))
-        with open(f"{file_root}/{aligned_filename}._mdiotemp", mode="wb") as fp:
+
+        aligned_filename = "/".join(map(str, dim_coords))
+        aligned_path = f"{file_root}/{aligned_filename}._mdiotemp"
+        os.makedirs(os.path.dirname(aligned_path), exist_ok=True)
+        with open(aligned_path, mode="wb") as fp:
             fp.write(buffer)
 
     return live_mask


### PR DESCRIPTION
Noticed some regression in performance with the new export logic. This PR optimizes the new SEG-Y export in #504 by doing the changes below. Improved performance quite a bit:

1. Reduce I/O operations during concatenation (open destination once)
2. Use directory separator `/` for tree write indices instead of `.` separator in indices.

Also fixed a bug: when blocks were being merged, we were not getting the correct size.