### PR TITLE
Remove mypy override for zarr module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,10 +127,6 @@ show_error_context = true
 disallow_untyped_defs = true # for strict mypy: (this is the tricky one)
 plugins = ["numpy.typing.mypy_plugin"]
 
-[[tool.mypy.overrides]]
-module = ["zarr"]
-ignore_missing_imports = true
-
 [tool.bumpversion]
 current_version = "0.9.0"
 allow_dirty = true


### PR DESCRIPTION
Zarr is pretty good with typing now; should be good.