### PR TITLE
V1 schema review

### DIFF
--- a/src/mdio/schemas/v1/variable.py
+++ b/src/mdio/schemas/v1/variable.py
@@ -33,7 +33,10 @@ CoordinateMetadata = create_model(
 
 
 class Coordinate(NamedArray):
-    """A simple MDIO Coordinate array with metadata. For large or complex Coordinates, define a Variable instead."""
+    """A simple MDIO Coordinate array with metadata.
+
+    For large or complex Coordinates, define a Variable instead.
+    """
 
     data_type: ScalarType = Field(..., description="Data type of Coordinate.")
     metadata: CoordinateMetadata | None = Field(default=None, description="Coordinate Metadata.")

--- a/src/mdio/schemas/v1/variable.py
+++ b/src/mdio/schemas/v1/variable.py
@@ -28,15 +28,15 @@ CoordinateMetadata = create_model(
     **model_fields(AllUnits),
     **model_fields(UserAttributes),
     __base__=CamelCaseStrictModel,
-    __doc__="Reduced Metadata, perfect for simple Coordinate arrays.",
+    __doc__="Reduced Metadata, perfect for simple Coordinates.",
 )
 
 
 class Coordinate(NamedArray):
-    """An MDIO coordinate array with metadata."""
+    """A simple MDIO Coordinate array with metadata. For large or complex Coordinates, define a Variable instead."""
 
-    data_type: ScalarType = Field(..., description="Data type of coordinate.")
-    metadata: CoordinateMetadata | None = Field(default=None, description="Coordinate metadata.")
+    data_type: ScalarType = Field(..., description="Data type of Coordinate.")
+    metadata: CoordinateMetadata | None = Field(default=None, description="Coordinate Metadata.")
 
 
 VariableMetadata = create_model(
@@ -51,10 +51,10 @@ VariableMetadata = create_model(
 
 
 class Variable(NamedArray):
-    """An MDIO variable that has coordinates and metadata."""
+    """An MDIO Variable that has coordinates and metadata."""
 
     coordinates: list[Coordinate] | list[str] | None = Field(
         default=None,
-        description="Coordinates of the MDIO variable dimensions.",
+        description="Coordinates of the MDIO Variable dimensions.",
     )
-    metadata: VariableMetadata | None = Field(default=None, description="Variable metadata.")
+    metadata: VariableMetadata | None = Field(default=None, description="Variable Metadata.")

--- a/src/mdio/schemas/v1/variable.py
+++ b/src/mdio/schemas/v1/variable.py
@@ -23,14 +23,19 @@ from mdio.schemas.metadata import UserAttributes
 from mdio.schemas.v1.stats import StatisticsMetadata
 from mdio.schemas.v1.units import AllUnits
 
+CoordinateMetadata = create_model(
+    "CoordinateMetadata",
+    **model_fields(AllUnits),
+    **model_fields(UserAttributes),
+    __base__=CamelCaseStrictModel,
+)
+
 
 class Coordinate(NamedArray):
     """An MDIO coordinate array with metadata."""
 
     data_type: ScalarType = Field(..., description="Data type of coordinate.")
-    metadata: list[AllUnits | UserAttributes] | None = Field(
-        default=None, description="Coordinate metadata."
-    )
+    metadata: CoordinateMetadata | None = Field(default=None, description="Coordinate metadata.")
 
 
 VariableMetadata = create_model(

--- a/src/mdio/schemas/v1/variable.py
+++ b/src/mdio/schemas/v1/variable.py
@@ -28,6 +28,7 @@ CoordinateMetadata = create_model(
     **model_fields(AllUnits),
     **model_fields(UserAttributes),
     __base__=CamelCaseStrictModel,
+    __doc__="Reduced Metadata, perfect for simple Coordinate arrays.",
 )
 
 
@@ -45,6 +46,7 @@ VariableMetadata = create_model(
     **model_fields(StatisticsMetadata),
     **model_fields(UserAttributes),
     __base__=CamelCaseStrictModel,
+    __doc__="Complete Metadata for Variables and complex or large Coordinates.",
 )
 
 


### PR DESCRIPTION
Coordinate metadata was required to be a list of units and attributes. This doesn't seem sensible since it only accepts a Scalar data type.

This PR updates a Coordinate to take a UnitsV1 object (singleton or list of) and UserAttributes. It also helps document when to define a Coordinate or a Variable.