### PR TITLE
v1 grid overrides: AutoChannelWrap

### DIFF
--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -113,25 +113,28 @@ def grid_density_qc(grid: Grid, num_traces: int) -> None:
 
 
 def _scan_for_headers(
-    segy_file: SegyFile, template: AbstractDatasetTemplate
+    segy_file: SegyFile, template: AbstractDatasetTemplate, grid_overrides: dict | None = None
 ) -> tuple[list[Dimension], SegyHeaderArray]:
     """Extract trace dimensions and index headers from the SEG-Y file.
 
     This is an expensive operation.
     It scans the SEG-Y file in chunks by using ProcessPoolExecutor
     """
-    # TODO(Dmitriy): implement grid overrides
-    # https://github.com/TGSAI/mdio-python/issues/585
-    # The 'grid_chunksize' is used only for grid_overrides
-    # While we do not support grid override, we can set it to None
-    grid_chunksize = None
-    segy_dimensions, chunksize, segy_headers = get_grid_plan(
+    trace_chunk_size = template.trace_chunk_size if grid_overrides is not None else None
+    segy_dimensions, chunk_size, segy_headers = get_grid_plan(
         segy_file=segy_file,
         return_headers=True,
         template=template,
-        chunksize=grid_chunksize,
-        grid_overrides=None,
+        chunksize=trace_chunk_size,
+        grid_overrides=grid_overrides,
     )
+    if trace_chunk_size != chunk_size:
+        # TODO(Dmitriy): implement grid overrides
+        # https://github.com/TGSAI/mdio-python/issues/585
+        # The returned 'chunksize' is used only for grid_overrides. We will need to use it when full
+        # support for grid overrides is implemented
+        err = "Support for changing trace_chunk_size in grid overrides is not yet implemented"
+        raise NotImplementedError(err)
     return segy_dimensions, segy_headers
 
 
@@ -403,6 +406,7 @@ def segy_to_mdio(
     input_location: StorageLocation,
     output_location: StorageLocation,
     overwrite: bool = False,
+    grid_overrides: dict | None = None,
 ) -> None:
     """A function that converts a SEG-Y file to an MDIO v1 file.
 
@@ -414,6 +418,7 @@ def segy_to_mdio(
         input_location: The storage location of the input SEG-Y file.
         output_location: The storage location for the output MDIO v1 file.
         overwrite: Whether to overwrite the output file if it already exists. Defaults to False.
+        grid_overrides: Option to add grid overrides.
 
     Raises:
         FileExistsError: If the output location already exists and overwrite is False.
@@ -426,11 +431,11 @@ def segy_to_mdio(
     segy_file = SegyFile(url=input_location.uri, spec=segy_spec, settings=segy_settings)
 
     # Scan the SEG-Y file for headers
-    segy_dimensions, segy_headers = _scan_for_headers(segy_file, mdio_template)
+    segy_dimensions, segy_headers = _scan_for_headers(segy_file, mdio_template, grid_overrides)
 
     grid = _build_and_check_grid(segy_dimensions, segy_file, segy_headers)
 
-    dimensions, non_dim_coords = _get_coordinates(grid, segy_headers, mdio_template)
+    _, non_dim_coords = _get_coordinates(grid, segy_headers, mdio_template)
     # TODO(Altay): Turn this dtype into packed representation
     # https://github.com/TGSAI/mdio-python/issues/601
     headers = to_structured_type(segy_spec.trace.header.dtype)

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -214,20 +214,97 @@ def populate_dim_coordinates(
     return dataset, drop_vars_delayed
 
 
-def populate_non_dim_coordinates(
+def _check_dimensions_values_identical(arr: np.ndarray, axes_to_check: tuple[int, ...]) -> bool:
+    """Check if all values along specified dimensions are identical.
+
+    Check if all values along specified dimensions are identical for each sub-array
+    defined by the other dimensions.
+
+    Args:
+        arr: an N-dimensional array. For example, an array of all 'cdp_x' segy
+            header values for coordinates "inline", "crossline", "offset", "azimuth".
+        axes_to_check: A tuple of integers representing the axes to check for
+            identical values. For example, (2, 3) would check the "offset", "azimuth"
+            dimensions.
+
+    Returns:
+        True indicates the all values in the dimensions selected by axes_to_check
+        are identical, and False otherwise.
+    """
+    # Create a slicing tuple to get the first element along the axes to check
+    full_slice = [slice(None)] * arr.ndim
+    for axis in axes_to_check:
+        full_slice[axis] = 0
+
+    # Broadcast the first element along the specified axes for comparison
+    first_element_slice = arr[tuple(full_slice)]
+
+    # Add new axes to the slice to enable broadcasting against the original array
+    for axis in axes_to_check:
+        first_element_slice = np.expand_dims(first_element_slice, axis)
+
+    # Compare the array with the broadcasted slice and use np.all()
+    # to collapse the dimensions being checked
+    identical = np.all(np.isclose(arr, first_element_slice), axis=axes_to_check)
+    return np.all(identical).item()
+
+
+def _populate_non_dim_coordinates(
     dataset: xr_Dataset,
     grid: Grid,
-    coordinates: dict[str, SegyHeaderArray],
+    coordinate_headers: dict[str, SegyHeaderArray],
     drop_vars_delayed: list[str],
 ) -> tuple[xr_Dataset, list[str]]:
     """Populate the xarray dataset with coordinate variables."""
-    not_null = grid.map[:] != UINT32_MAX
-    for c_name, c_values in coordinates.items():
-        c_tmp_array = dataset[c_name].values
-        c_tmp_array[not_null] = c_values
-        dataset[c_name][:] = c_tmp_array
+    coord_is_good = {}
+    # Load the grid map values into memory.
+    # Q: Should we be using the trace_mask boolean array instead of grid map?
+    grid_map_values = grid.map[:]
+    for c_name, coord_headers_values in coordinate_headers.items():
+        headers_dims = grid.dim_names[:-1]  # e.g.: "inline", "crossline", "offset", "azimuth"
+        coord_dims = dataset[c_name].dims  # e.g.: "inline", "crossline"
+        axes_to_check = tuple(i for i, dim in enumerate(headers_dims) if dim not in coord_dims)
+        if axes_to_check == ():
+            # In case the coordinate has the same dimensions as grid map
+            coord_is_good[c_name] = True
+            not_null = grid_map_values != UINT32_MAX
+            tmp_coord_values = dataset[c_name].values
+            tmp_coord_values[not_null] = coord_headers_values
+        else:
+            # In the case of Coca and some other templates, the coordinate header values,
+            # coord_headers_values, have a full set of dimensions (e.g. a 4-tuple of "inline",
+            # "crossline", "offset", "azimuth"), while the non-dimensional coordinates, (e.g.,
+            # dataset["cdp_x"]) are defined over only a subset of the dimensions (e.g. 2-tuple of
+            # "inline", "crossline").
+            # Thus, every coordinate 2-tuple has multiple duplicate values of the "cdp_x" coordinates
+            # stored in coord_headers_values. Those needs to be reduced to a unique value.
+            # We assume (and check) that all the duplicate values are (near) identical.
+            #
+            # The following will create a temporary array in memory with the same shape as the
+            # coordinate defined in the dataset. Since the coordinate variable has not yet been
+            # populated, the temporary array will be populated with NaN from the current coordinate
+            # values.
+            tmp_coord_values = dataset[c_name].values
+            # Create slices for the all grid dimensions that are also the coordinate dimensions.
+            # For other dimension, select the first element (with index 0)
+            slices = tuple(slice(None) if name in coord_dims else 0 for name in headers_dims)
+            # Create a boolean mask for the live trace values with the dimensions of the coordinate
+            # Q: Should we be using the trace_mask boolean array instead of grid map?
+            not_null = grid_map_values[slices] != UINT32_MAX
+
+            ch_reshaped = coord_headers_values.reshape(grid_map_values.shape)
+            # Select a subset of the coordinate_headers that have unique values
+            cr_reduced = ch_reshaped[slices]
+
+            # Validate the all reduced dimensions had identical values
+            coord_is_good[c_name] = _check_dimensions_values_identical(ch_reshaped, axes_to_check)
+
+            # Save the unique coordinate values for live traces only
+            tmp_coord_values[not_null] = cr_reduced.ravel()
+
+        dataset[c_name][:] = tmp_coord_values
         drop_vars_delayed.append(c_name)
-    return dataset, drop_vars_delayed
+    return coord_is_good, dataset, drop_vars_delayed
 
 
 def _get_horizontal_coordinate_unit(segy_headers: list[Dimension]) -> AllUnits | None:
@@ -263,17 +340,25 @@ def _populate_coordinates(
         grid: The grid object containing the grid map.
         coords: The non-dim coordinates to populate.
 
+    Raises:
+        ValueError: If coordinate headers have non-identical values for the reduced dimensions.
+
     Returns:
-        Xarray dataset with filled coordinates and updated variables to drop after writing
+        A tuple of the Xarray dataset with filled coordinates and updated variables to drop
+        after writing
     """
     drop_vars_delayed = []
     # Populate the dimension coordinate variables (1-D arrays)
-    dataset, vars_to_drop_later = populate_dim_coordinates(dataset, grid, drop_vars_delayed=drop_vars_delayed)
+    dataset, drop_vars_delayed = populate_dim_coordinates(dataset, grid, drop_vars_delayed=drop_vars_delayed)
 
     # Populate the non-dimension coordinate variables (N-dim arrays)
-    dataset, vars_to_drop_later = populate_non_dim_coordinates(
-        dataset, grid, coordinates=coords, drop_vars_delayed=drop_vars_delayed
+    is_good, dataset, drop_vars_delayed = _populate_non_dim_coordinates(
+        dataset, grid, coordinate_headers=coords, drop_vars_delayed=drop_vars_delayed
     )
+    if not all(is_good.values()):
+        failed_dims = [key for key, value in is_good.items() if not value]
+        err = f"Non-dim coordinate(s) {failed_dims} have non-identical values " + "along reduced dimensions."
+        raise ValueError(err)
 
     return dataset, drop_vars_delayed
 

--- a/src/mdio/core/utils_read.py
+++ b/src/mdio/core/utils_read.py
@@ -1,0 +1,16 @@
+"""Utils for reading MDIO dataset"""
+
+from typing import TYPE_CHECKING
+
+from xarray import open_dataset as xr_open_dataset
+from mdio.core.storage_location import StorageLocation
+from xarray import Dataset as xr_Dataset
+
+def open_zarr_dataset(storage_location: StorageLocation) -> xr_Dataset:
+    """
+    Open a Zarr dataset from the specified storage location.
+    """
+    # NOTE: If mask_and_scale is not set,
+    # Xarray will convert int to float and replace _FillValue with NaN
+    # We are using chunks={} to force Xarray to create Dask arrays
+    return xr_open_dataset(storage_location.uri, engine="zarr", chunks={}, mask_and_scale=False)

--- a/src/mdio/schemas/v1/templates/abstract_dataset_template.py
+++ b/src/mdio/schemas/v1/templates/abstract_dataset_template.py
@@ -121,6 +121,11 @@ class AbstractDatasetTemplate(ABC):
         return copy.deepcopy(self._coord_names)
 
     @property
+    def trace_chunk_size(self) -> list[int]:
+        """Returns the chunk size for the variables."""
+        return copy.deepcopy(self._var_chunk_shape)
+
+    @property
     @abstractmethod
     def _name(self) -> str:
         """Abstract method to get the name of the template.

--- a/src/mdio/schemas/v1/templates/abstract_dataset_template.py
+++ b/src/mdio/schemas/v1/templates/abstract_dataset_template.py
@@ -84,7 +84,9 @@ class AbstractDatasetTemplate(ABC):
         self._dim_sizes = sizes
         self._horizontal_coord_unit = horizontal_coord_unit
 
-        self._builder = MDIODatasetBuilder(name=name, attributes=self._load_dataset_attributes())
+        attr = self._load_dataset_attributes() or UserAttributes(attributes={})
+        attr.attributes["traceVariableName"] = self._trace_variable_name
+        self._builder = MDIODatasetBuilder(name=name, attributes=attr)
         self._add_dimensions()
         self._add_coordinates()
         self._add_variables()

--- a/src/mdio/schemas/v1/templates/seismic_3d_prestack_coca.py
+++ b/src/mdio/schemas/v1/templates/seismic_3d_prestack_coca.py
@@ -12,8 +12,8 @@ class Seismic3DPreStackCocaTemplate(AbstractDatasetTemplate):
     def __init__(self, domain: str):
         super().__init__(domain=domain)
 
-        self._coord_dim_names = ["inline", "crossline", "offset", "azimuth"]
-        self._dim_names = [*self._coord_dim_names, self._trace_domain]
+        self._coord_dim_names = ["inline", "crossline"]  # This could be a dictionary specific to every coord
+        self._dim_names = [*self._coord_dim_names, "offset", "azimuth", self._trace_domain]
         self._coord_names = ["cdp_x", "cdp_y"]
         self._var_chunk_shape = [8, 8, 32, 1, 1024]
 
@@ -64,13 +64,13 @@ class Seismic3DPreStackCocaTemplate(AbstractDatasetTemplate):
         # Add non-dimension coordinates
         self._builder.add_coordinate(
             "cdp_x",
-            dimensions=["inline", "crossline"],
+            dimensions=self._coord_dim_names,
             data_type=ScalarType.FLOAT64,
             metadata_info=[self._horizontal_coord_unit],
         )
         self._builder.add_coordinate(
             "cdp_y",
-            dimensions=["inline", "crossline"],
+            dimensions=self._coord_dim_names,
             data_type=ScalarType.FLOAT64,
             metadata_info=[self._horizontal_coord_unit],
         )

--- a/src/mdio/segy/creation.py
+++ b/src/mdio/segy/creation.py
@@ -7,98 +7,80 @@ from dataclasses import dataclass
 from pathlib import Path
 from shutil import copyfileobj
 from typing import TYPE_CHECKING
-from typing import Any
 
 import numpy as np
+import xarray as xr
 from segy.factory import SegyFactory
-from segy.schema import Endianness
 from segy.schema import SegySpec
 from tqdm.auto import tqdm
+from xarray import Dataset as xr_Dataset
 
-from mdio.api.accessor import MDIOReader
-from mdio.segy.compat import mdio_segy_spec
+from mdio.core.utils_read import open_zarr_dataset
 from mdio.segy.compat import revision_encode
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
+    from mdio.core.storage_location import StorageLocation
+
 
 logger = logging.getLogger(__name__)
 
 
-def make_segy_factory(mdio: MDIOReader, spec: SegySpec) -> SegyFactory:
+def make_segy_factory(mdio_xr: xr_Dataset, spec: SegySpec) -> SegyFactory:
     """Generate SEG-Y factory from MDIO metadata."""
-    grid = mdio.grid
-    sample_dim = grid.select_dim("sample")
-    sample_interval = sample_dim[1] - sample_dim[0]
-    samples_per_trace = len(sample_dim)
-
+    binary_header = mdio_xr.attrs["attributes"]["binaryHeader"]
+    sample_interval = binary_header["sample_interval"]
+    samples_per_trace = binary_header["samples_per_trace"]
     return SegyFactory(
         spec=spec,
-        sample_interval=sample_interval * 1000,
+        sample_interval=sample_interval,  # Sample Interval is already in milliseconds
         samples_per_trace=samples_per_trace,
     )
 
 
-def mdio_spec_to_segy(  # noqa: PLR0913
-    mdio_path_or_buffer: str,
-    output_segy_path: Path,
-    access_pattern: str,
-    output_endian: str,
-    storage_options: dict[str, Any],
-    new_chunks: tuple[int, ...],
-    backend: str,
-) -> tuple[MDIOReader, SegyFactory]:
+def mdio_spec_to_segy(
+    segy_spec: SegySpec,
+    input_location: StorageLocation,
+    output_location: StorageLocation
+) -> tuple[xr_Dataset, SegyFactory]:
     """Create SEG-Y file without any traces given MDIO specification.
 
     This function opens an MDIO file, gets some relevant information for SEG-Y files, then creates
     a SEG-Y file with the specification it read from the MDIO file.
 
-    It then returns the `MDIOReader` instance, and the parsed floating point format `sample_format`
-    for further use.
+    It then returns the Xarray Dataset instance and SegyFactory for further use.
 
-    Function will attempt to read text, and binary headers, and some grid information from the MDIO
-    file. If these don't exist, the process will fail.
+    Function will attempt to read text, and binary headers information from the MDIO file.
+    If these don't exist, the process will fail.
 
     Args:
-        mdio_path_or_buffer: Store or URL for MDIO file.
-        output_segy_path: Path to the output SEG-Y file.
-        access_pattern: Chunk access pattern, optional. Default is "012". Examples: '012', '01'.
-        output_endian: Endianness of the output file.
-        storage_options: Options for the storage backend. By default, system-wide credentials
-            will be used.
-        new_chunks: Set manual chunksize. For development purposes only.
-        backend: Backend selection, optional. Default is "zarr". Must be in {'zarr', 'dask'}.
+        segy_spec: The SEG-Y specification to use for the conversion.
+        input_location: Store or URL (and cloud options) for MDIO file.
+        output_location: Path to the output SEG-Y file.
 
     Returns:
-        Initialized MDIOReader for MDIO file and return SegyFactory
+        Opened Xarray Dataset for MDIO file and SegyFactory
     """
-    mdio = MDIOReader(
-        mdio_path_or_buffer=mdio_path_or_buffer,
-        access_pattern=access_pattern,
-        storage_options=storage_options,
-        return_metadata=True,
-        new_chunks=new_chunks,
-        backend=backend,
-        disk_cache=False,  # Making sure disk caching is disabled
-    )
+    mdio_xr = open_zarr_dataset(input_location)
+    factory = make_segy_factory(mdio_xr, spec=segy_spec)
 
-    mdio_file_version = mdio.root.attrs["api_version"]
-    spec = mdio_segy_spec(mdio_file_version)
-    spec.endianness = Endianness(output_endian)
-    factory = make_segy_factory(mdio, spec=spec)
+    attr = mdio_xr.attrs["attributes"]
 
-    text_str = "\n".join(mdio.text_header)
+    txt_header = attr["textHeader"]
+    text_str = "\n".join(txt_header)
     text_bytes = factory.create_textual_header(text_str)
 
-    binary_header = revision_encode(mdio.binary_header, mdio_file_version)
+    bin_header = attr["binaryHeader"]
+    mdio_file_version = mdio_xr.attrs["apiVersion"]
+    binary_header = revision_encode(bin_header, mdio_file_version)
     bin_hdr_bytes = factory.create_binary_header(binary_header)
 
-    with output_segy_path.open(mode="wb") as fp:
+    with Path(output_location.uri).open(mode="wb") as fp:
         fp.write(text_bytes)
         fp.write(bin_hdr_bytes)
 
-    return mdio, factory
+    return mdio_xr, factory
 
 
 @dataclass(slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from urllib.request import urlretrieve
 
 import pytest
 
-DEBUG_MODE = True
+DEBUG_MODE = False
 
 # Suppress Dask's chunk balancing warning
 warnings.filterwarnings(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from urllib.request import urlretrieve
 
 import pytest
 
-DEBUG_MODE = False
+DEBUG_MODE = True
 
 # Suppress Dask's chunk balancing warning
 warnings.filterwarnings(
@@ -18,13 +18,24 @@ warnings.filterwarnings(
     module="dask.array.rechunk",
 )
 
+@pytest.fixture
+def export_masked_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Fixture that generates temp directory for export tests."""
+    if DEBUG_MODE:
+        return Path("TMP/export_masked")
+    return tmp_path_factory.getbasetemp() / "export_masked"
+
 
 @pytest.fixture(scope="session")
 def fake_segy_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the fake SEG-Y files we are going to create."""
     if DEBUG_MODE:
-        return Path("TMP/fake_segy")
-    return tmp_path_factory.mktemp(r"fake_segy")
+        tmp_dir = Path("TMP/fake_segy")
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        tmp_dir = tmp_path_factory.mktemp(r"fake_segy")
+    return tmp_dir
+
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from pathlib import Path
 from urllib.request import urlretrieve
 
 import pytest
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
+DEBUG_MODE = False
 
 # Suppress Dask's chunk balancing warning
 warnings.filterwarnings(
@@ -24,6 +22,8 @@ warnings.filterwarnings(
 @pytest.fixture(scope="session")
 def fake_segy_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the fake SEG-Y files we are going to create."""
+    if DEBUG_MODE:
+        return Path("TMP/fake_segy")
     return tmp_path_factory.mktemp(r"fake_segy")
 
 
@@ -36,27 +36,38 @@ def segy_input_uri() -> str:
 @pytest.fixture(scope="session")
 def segy_input(segy_input_uri: str, tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Download teapot dome dataset for testing."""
-    tmp_dir = tmp_path_factory.mktemp("segy")
+    if DEBUG_MODE:
+        tmp_dir = Path("TMP/segy")
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        tmp_dir = tmp_path_factory.mktemp("segy")
     tmp_file = tmp_dir / "teapot.segy"
     urlretrieve(segy_input_uri, tmp_file)  # noqa: S310
-
     return tmp_file
 
 
 @pytest.fixture(scope="module")
 def zarr_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the output MDIO."""
+    if DEBUG_MODE:
+        return Path("TMP/mdio")
     return tmp_path_factory.mktemp(r"mdio")
 
 
 @pytest.fixture(scope="module")
 def zarr_tmp2(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the output MDIO."""
+    if DEBUG_MODE:
+        return Path("TMP/mdio2")
     return tmp_path_factory.mktemp(r"mdio2")
 
 
 @pytest.fixture(scope="session")
 def segy_export_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the round-trip IBM SEG-Y."""
-    tmp_dir = tmp_path_factory.mktemp("segy")
+    if DEBUG_MODE:
+        tmp_dir = Path("TMP/segy")
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        tmp_dir = tmp_path_factory.mktemp("segy")
     return tmp_dir / "teapot_roundtrip.segy"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,8 +19,9 @@ if TYPE_CHECKING:
     from segy.schema import SegySpec
 
 
-def _segy_spec_mock_4d() -> SegySpec:
-    """Create a mock SEG-Y spec for 4D data."""
+def get_segy_mock_4d_spec() -> SegySpec:
+    """Create a mock 4D SEG-Y specification."""
+
     trace_header_fields = [
         HeaderField(name="field_rec_no", byte=9, format="int32"),
         HeaderField(name="channel", byte=13, format="int32"),
@@ -31,6 +32,14 @@ def _segy_spec_mock_4d() -> SegySpec:
         HeaderField(name="shot_line", byte=133, format="int16"),
         HeaderField(name="cable", byte=137, format="int16"),
         HeaderField(name="gun", byte=171, format="int16"),
+
+        HeaderField(name="coordinate_scalar", byte=71, format="int16"),
+        HeaderField(name="source_coord_x", byte=73, format="int32"),
+        HeaderField(name="source_coord_y", byte=77, format="int32"),
+        HeaderField(name="group_coord_x", byte=81, format="int32"),
+        HeaderField(name="group_coord_y", byte=85, format="int32"),
+        HeaderField(name="cdp_x", byte=181, format="int32"),
+        HeaderField(name="cdp_y", byte=185, format="int32"),
     ]
     rev1_spec = get_segy_standard(1.0)
     spec = rev1_spec.customize(trace_header_fields=trace_header_fields)
@@ -83,7 +92,7 @@ def create_segy_mock_4d(  # noqa: PLR0913
     channel_headers = np.tile(channel_headers, shot_count)
 
     factory = SegyFactory(
-        spec=_segy_spec_mock_4d(),
+        spec=get_segy_mock_4d_spec(),
         sample_interval=1000,
         samples_per_trace=num_samples,
     )
@@ -91,25 +100,48 @@ def create_segy_mock_4d(  # noqa: PLR0913
     headers = factory.create_trace_header_template(trace_count)
     samples = factory.create_trace_sample_template(trace_count)
 
-    for trc_idx in range(trace_count):
-        shot = shot_headers[trc_idx]
-        gun = gun_headers[trc_idx]
-        cable = cable_headers[trc_idx]
-        channel = channel_headers[trc_idx]
-        shot_line = 1
-        offset = 0
+    start_x = 700000
+    start_y = 4000000
+    step_x = 100
+    step_y = 100
 
-        if index_receivers is False:
-            channel, gun, shot_line = 0, 0, 0
+    # trace_count = shot_count * total_chan
+    for trc_shot_idx  in range(shot_count):
+        for trc_chan_idx  in range(total_chan):
+            # for trc_idx in range(trace_count):
+            trc_idx = trc_shot_idx * total_chan + trc_chan_idx
 
-        header_data = (shot, channel, shot, offset, shot_line, cable, gun)
+            shot = shot_headers[trc_idx]
+            gun = gun_headers[trc_idx]
+            cable = cable_headers[trc_idx]
+            channel = channel_headers[trc_idx]
+            shot_line = 1
+            offset = 0
 
-        fields = list(headers.dtype.names)
-        fields.remove("samples_per_trace")
-        fields.remove("sample_interval")
+            if index_receivers is False:
+                channel, gun, shot_line = 0, 0, 0
 
-        headers[fields][trc_idx] = header_data
-        samples[trc_idx] = np.linspace(start=shot, stop=shot + 1, num=num_samples)
+            headers["field_rec_no"][trc_idx] = shot
+            headers["channel"][trc_idx] = channel
+            headers["shot_point"][trc_idx] = shot
+            headers["offset"][trc_idx] = offset
+            # headers["samples_per_trace"][trc_idx] = 1000
+            # headers["sample_interval"][trc_idx] = num_samples
+            headers["shot_line"][trc_idx] = shot_line
+            headers["cable"][trc_idx] = cable
+            headers["gun"][trc_idx] = gun
+
+            x = start_x + step_x * trc_shot_idx 
+            y = start_y + step_y * trc_chan_idx 
+            headers["coordinate_scalar"][trc_idx] = -100
+            headers["source_coord_x"][trc_idx] = x
+            headers["source_coord_y"][trc_idx] = y
+            headers["group_coord_x"][trc_idx] = x
+            headers["group_coord_y"][trc_idx] = y
+            headers["cdp_x"][trc_idx] = x
+            headers["cdp_y"][trc_idx] = y
+
+            samples[trc_idx] = np.linspace(start=shot, stop=shot + 1, num=num_samples)
 
     with segy_path.open(mode="wb") as fp:
         fp.write(factory.create_textual_header())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,27 @@ from mdio.segy.geometry import StreamerShotGeometryType
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from segy.schema import SegySpec
+
+
+def _segy_spec_mock_4d() -> SegySpec:
+    """Create a mock SEG-Y spec for 4D data."""
+    trace_header_fields = [
+        HeaderField(name="field_rec_no", byte=9, format="int32"),
+        HeaderField(name="channel", byte=13, format="int32"),
+        HeaderField(name="shot_point", byte=17, format="int32"),
+        HeaderField(name="offset", byte=37, format="int32"),
+        HeaderField(name="samples_per_trace", byte=115, format="int32"),
+        HeaderField(name="sample_interval", byte=117, format="int32"),
+        HeaderField(name="shot_line", byte=133, format="int16"),
+        HeaderField(name="cable", byte=137, format="int16"),
+        HeaderField(name="gun", byte=171, format="int16"),
+    ]
+    rev1_spec = get_segy_standard(1.0)
+    spec = rev1_spec.customize(trace_header_fields=trace_header_fields)
+    spec.segy_standard = SegyStandard.REV1
+    return spec
+
 
 def create_segy_mock_4d(  # noqa: PLR0913
     fake_segy_tmp: Path,
@@ -61,23 +82,8 @@ def create_segy_mock_4d(  # noqa: PLR0913
     cable_headers = np.tile(cable_headers, shot_count)
     channel_headers = np.tile(channel_headers, shot_count)
 
-    trace_header_fields = [
-        HeaderField(name="field_rec_no", byte=9, format="int32"),
-        HeaderField(name="channel", byte=13, format="int32"),
-        HeaderField(name="shot_point", byte=17, format="int32"),
-        HeaderField(name="offset", byte=37, format="int32"),
-        HeaderField(name="samples_per_trace", byte=115, format="int32"),
-        HeaderField(name="sample_interval", byte=117, format="int32"),
-        HeaderField(name="shot_line", byte=133, format="int16"),
-        HeaderField(name="cable", byte=137, format="int16"),
-        HeaderField(name="gun", byte=171, format="int16"),
-    ]
-
-    rev1_spec = get_segy_standard(1.0)
-    spec = rev1_spec.customize(trace_header_fields=trace_header_fields)
-    spec.segy_standard = SegyStandard.REV1
     factory = SegyFactory(
-        spec=spec,
+        spec=_segy_spec_mock_4d(),
         sample_interval=1000,
         samples_per_trace=num_samples,
     )

--- a/tests/integration/test_segy_import_export.py
+++ b/tests/integration/test_segy_import_export.py
@@ -144,7 +144,7 @@ class TestImport4D:
         assert np.array_equal(ds["shot_point"].values, shots)
         assert np.array_equal(ds["cable"].values, cables)
 
-        if chan_header_type == StreamerShotGeometryType.B and grid_overrides is None:
+        if chan_header_type == StreamerShotGeometryType.B and grid_overrides == {}:
             expected = [i for i in range(1, np.sum(receivers_per_cable) + 1)]
         else:
             expected = [i for i in range(1, np.amax(receivers_per_cable) + 1)]
@@ -203,7 +203,7 @@ class TestImport6D:
             case "AutoChannelWrap_AutoShotWrap":
                 grid_overrides = {"AutoChannelWrap": True, "AutoShotWrap": True}
             case _:
-                grid_overrides =  None
+                grid_overrides =  {}
 
         segy_spec: SegySpec = get_segy_mock_4d_spec()
         segy_path = segy_mock_4d_shots[chan_header_type]
@@ -239,7 +239,7 @@ class TestImport6D:
         assert np.array_equal(ds["shot_point"].values, shots)
         assert np.array_equal(ds["cable"].values, cables)
 
-        if chan_header_type == StreamerShotGeometryType.B and grid_overrides is None:
+        if chan_header_type == StreamerShotGeometryType.B and grid_overrides == {}:
             expected = [i for i in range(1, np.sum(receivers_per_cable) + 1)]
         else:
             expected = [i for i in range(1, np.amax(receivers_per_cable) + 1)]

--- a/tests/integration/test_segy_import_export.py
+++ b/tests/integration/test_segy_import_export.py
@@ -184,7 +184,7 @@ class TestImport4DSparse:
         assert "This grid is very sparse and most likely user error with indexing." in str(execinfo.value)
 
         pass
-
+@pytest.mark.skip(reason="AutoShotWrap requires a template that is not implemented yet.")
 @pytest.mark.parametrize("grid_override", ["AutoChannelWrap_AutoShotWrap", None])
 @pytest.mark.parametrize("chan_header_type", [StreamerShotGeometryType.A, StreamerShotGeometryType.B])
 class TestImport6D:
@@ -210,8 +210,11 @@ class TestImport6D:
 
         # chunksize=(1, 1, 8, 1, 12, 36),
 
-        assert False, "6D template is not implemented yet."
-        template_name = "XYZ"  # Placeholder for the
+        # The "AutoShotWrap" grid overide requires a template with dimensions 
+        # 'channel', 'cable', 'gun', 'shot_line', 'shot_point'
+        # When such template is available, we shall enable this test
+        assert False, "Template for AutoShotWrap is not implemented yet."
+        template_name = "XYZ"  # Placeholder for the template
         segy_to_mdio(
             segy_spec=segy_spec,
             mdio_template=TemplateRegistry().get(template_name),

--- a/tests/integration/test_segy_import_export.py
+++ b/tests/integration/test_segy_import_export.py
@@ -82,6 +82,7 @@ class TestImport4DNonReg:
         ds = open_zarr_dataset(StorageLocation(str(zarr_tmp)))
 
         assert ds.attrs["attributes"]["binaryHeader"]["samples_per_trace"] == num_samples
+        assert ds.attrs["attributes"]["gridOverrides"] == grid_overrides 
 
         assert np.array_equal(ds["shot_point"].values, shots)
         assert np.array_equal(ds["cable"].values, cables)
@@ -112,7 +113,7 @@ class TestImport4D:
             case "AutoChannelWrap":
                 grid_overrides = {"AutoChannelWrap": True}
             case _:
-                grid_overrides =  None
+                grid_overrides =  {}
       
         segy_spec: SegySpec = get_segy_mock_4d_spec()
         segy_path = segy_mock_4d_shots[chan_header_type]
@@ -137,6 +138,8 @@ class TestImport4D:
         ds = open_zarr_dataset(StorageLocation(str(zarr_tmp)))
 
         assert ds.attrs["attributes"]["binaryHeader"]["samples_per_trace"] == num_samples
+        assert ds.attrs["attributes"]["gridOverrides"] == grid_overrides 
+
 
         assert np.array_equal(ds["shot_point"].values, shots)
         assert np.array_equal(ds["cable"].values, cables)
@@ -292,7 +295,7 @@ class TestReader:
 
         attributes = ds.attrs["attributes"]
         assert attributes is not None
-        assert len(attributes) == 6
+        assert len(attributes) == 7
         # Validate all attribute provided by the abstract template
         assert attributes["traceVariableName"] == "amplitude"
         # Validate attributes provided by the PostStack3DTime template
@@ -303,6 +306,7 @@ class TestReader:
         assert attributes["textHeader"] == text_header_teapot_dome()
         # Validate binary header
         assert attributes["binaryHeader"] == binary_header_teapot_dome()
+        assert attributes["gridOverrides"] == {}
 
     def test_meta_variable(self, zarr_tmp: Path) -> None:
         """Metadata reading tests."""

--- a/tests/integration/test_segy_import_export_masked.py
+++ b/tests/integration/test_segy_import_export_masked.py
@@ -162,7 +162,7 @@ def _segy_spec_mock_nd_segy(grid_conf: GridConfig, segy_factory_conf: SegyFactor
     # Add coordinates: {SRC-REC-CDP}-X/Y
     header_flds.extend(
         [
-            HeaderField(name="coord_scalar", byte=71, format="int16"),
+            HeaderField(name="coordinate_scalar", byte=71, format="int16"),
             HeaderField(name="source_coord_x", byte=73, format="int32"),
             HeaderField(name="source_coord_y", byte=77, format="int32"),
             HeaderField(name="group_coord_x", byte=81, format="int32"),
@@ -210,13 +210,13 @@ def mock_nd_segy(path: str, grid_conf: GridConfig, segy_factory_conf: SegyFactor
         # Make sure that multiple cdp_x and cdp_y values are the same for each (il, xl)
         cdp_x = 700000 + 100 * inline + crossline
         cdp_y = 4000000 + inline + 1000 * crossline
-        headers["coord_scalar"] = -100
+        headers["coordinate_scalar"] = -100
         for field in ["cdp_x", "source_coord_x", "group_coord_x"]:
             headers[field] = cdp_x.ravel()
         for field in ["cdp_y", "source_coord_y", "group_coord_y"]:
             headers[field] = cdp_y.ravel()
     else:
-        headers["coord_scalar"] = -100
+        headers["coordinate_scalar"] = -100
         for field in ["cdp_x", "source_coord_x", "group_coord_x"]:
             start = 700000
             step = 100
@@ -260,15 +260,6 @@ def generate_selection_mask(selection_conf: SelectionMaskConfig, grid_conf: Grid
     selection_mask[rand_idx] = True
 
     return selection_mask
-
-
-@pytest.fixture
-def export_masked_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Fixture that generates temp directory for export tests."""
-    if DEBUG_MODE:
-        return Path("TMP/export_masked")
-    return tmp_path_factory.getbasetemp() / "export_masked"
-
 
 # fmt: off
 @pytest.mark.parametrize(
@@ -376,7 +367,7 @@ class TestNdImportExport:
             expected_y = 4000000 + trace_index * 100
         expected_gun = 1 + (trace_index % 3)
         # validate
-        assert trace_header["coord_scalar"] == -100
+        assert trace_header["coordinate_scalar"] == -100
         assert trace_header["source_coord_x"] == expected_x
         assert trace_header["source_coord_y"] == expected_y
         assert trace_header["group_coord_x"] == expected_x

--- a/tests/integration/test_segy_import_export_masked.py
+++ b/tests/integration/test_segy_import_export_masked.py
@@ -201,17 +201,32 @@ def mock_nd_segy(path: str, grid_conf: GridConfig, segy_factory_conf: SegyFactor
         headers[dim.name] = dim_grid[dim_idx].ravel()
 
     # Fill coordinates (e.g. {SRC-REC-CDP}-X/Y
-    headers["coord_scalar"] = -100
-    for field in ["cdp_x", "source_coord_x", "group_coord_x"]:
-        start = 700000
-        step = 100
-        stop = start + step * (trace_numbers.size - 0)
-        headers[field] = np.arange(start=start, stop=stop, step=step)
-    for field in ["cdp_y", "source_coord_y", "group_coord_y"]:
-        start = 4000000
-        step = 100
-        stop = start + step * (trace_numbers.size - 0)
-        headers[field] = np.arange(start=start, stop=stop, step=step)
+    if grid_conf.name == "3d_coca":
+        coords = []
+        for name in ["inline", "crossline", "offset", "azimuth"]:
+            dim = next(dim for dim in grid_conf.dims if dim.name == name)
+            coords.append(np.arange(start=dim.start, stop=dim.start + dim.size * dim.step, step=dim.step))
+        inline, crossline, _, _ = np.meshgrid(*coords, indexing="ij")
+        # Make sure that multiple cdp_x and cdp_y values are the same for each (il, xl)
+        cdp_x = 700000 + 100 * inline + crossline
+        cdp_y = 4000000 + inline + 1000 * crossline
+        headers["coord_scalar"] = -100
+        for field in ["cdp_x", "source_coord_x", "group_coord_x"]:
+            headers[field] = cdp_x.ravel()
+        for field in ["cdp_y", "source_coord_y", "group_coord_y"]:
+            headers[field] = cdp_y.ravel()
+    else:
+        headers["coord_scalar"] = -100
+        for field in ["cdp_x", "source_coord_x", "group_coord_x"]:
+            start = 700000
+            step = 100
+            stop = start + step * (trace_numbers.size - 0)
+            headers[field] = np.arange(start=start, stop=stop, step=step)
+        for field in ["cdp_y", "source_coord_y", "group_coord_y"]:
+            start = 4000000
+            step = 100
+            stop = start + step * (trace_numbers.size - 0)
+            headers[field] = np.arange(start=start, stop=stop, step=step)
 
     # Array filled with repeating sequence
     sequence = np.array([1, 2, 3])
@@ -287,8 +302,8 @@ class TestNdImportExport:
                 template_name = "PreStackShotGathers2D" + domain
             case "3d_streamer":
                 template_name = "PreStackShotGathers3D" + domain
-            # case "3d_coca":
-            #     templateName = "PostStack3D" + domain
+            case "3d_coca":
+                template_name = "PreStackCocaGathers3D" + domain
             case _:
                 err = f"Unsupported test configuration: {grid_conf.name}"
                 raise ValueError(err)
@@ -339,11 +354,28 @@ class TestNdImportExport:
         assert headers.shape == live_mask.shape
         assert set(headers.dims) == {dim.name for dim in grid_conf.dims}
         # Validate header values
-        trace_index = 0
-        trace_header = headers.values.flatten()[trace_index]
-        expected_x = 700000 + trace_index * 100
-        expected_y = 4000000 + trace_index * 100
+        if grid_conf.name == "3d_coca":
+            # Select an index of the trace, which header to check:
+            il, xl, of, az = 0, 0, 0, 0
+            trace_index = np.ravel_multi_index((il, xl, of, az), dims=live_mask.shape)
+            # Get the trace header
+            trace_header = headers.values[il][xl][of][az]
+            # calculate the expected values
+            coords = {}
+            for name in ["inline", "crossline", "offset", "azimuth"]:
+                dim = next(dim for dim in grid_conf.dims if dim.name == name)
+                coords[name] = np.arange(start=dim.start, stop=dim.start + dim.size * dim.step, step=dim.step)
+            inline = coords["inline"][il]
+            crossline = coords["crossline"][xl]
+            expected_x = 700000 + 100*inline + crossline
+            expected_y = 4000000 + inline + 1000*crossline
+        else:
+            trace_index = 0
+            trace_header = headers.values.flatten()[trace_index]
+            expected_x = 700000 + trace_index * 100
+            expected_y = 4000000 + trace_index * 100
         expected_gun = 1 + (trace_index % 3)
+        # validate
         assert trace_header["coord_scalar"] == -100
         assert trace_header["source_coord_x"] == expected_x
         assert trace_header["source_coord_y"] == expected_y

--- a/tests/integration/test_segy_import_export_masked.py
+++ b/tests/integration/test_segy_import_export_masked.py
@@ -21,17 +21,16 @@ from segy.factory import SegyFactory
 from segy.schema import HeaderField
 from segy.schema import SegySpec
 from segy.standards import get_segy_standard
+from tests.conftest import DEBUG_MODE
 
-from mdio import MDIOReader
 from mdio import mdio_to_segy
+from mdio.core.utils_read import open_zarr_dataset
 from mdio.converters.segy import segy_to_mdio
 from mdio.core.storage_location import StorageLocation
 from mdio.schemas.v1.templates.template_registry import TemplateRegistry
-from mdio.segy.utilities import segy_export_rechunker
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pathlib import Path
 
     from numpy.typing import NDArray
 
@@ -150,10 +149,8 @@ COCA_3D_CONF = MaskedExportConfig(
 # fmt: on
 
 
-def mock_nd_segy(path: str, grid_conf: GridConfig, segy_factory_conf: SegyFactoryConfig) -> SegySpec:
-    """Create a fake SEG-Y file with a multidimensional grid."""
+def _segy_spec_mock_nd_segy(grid_conf: GridConfig, segy_factory_conf: SegyFactoryConfig) -> SegySpec:
     spec = get_segy_standard(segy_factory_conf.revision)
-
     header_flds = []
     for dim in grid_conf.dims:
         byte_loc = segy_factory_conf.header_byte_map[dim.name]
@@ -179,6 +176,12 @@ def mock_nd_segy(path: str, grid_conf: GridConfig, segy_factory_conf: SegyFactor
 
     spec = spec.customize(trace_header_fields=header_flds)
     spec.segy_standard = segy_factory_conf.revision
+    return spec
+
+
+def mock_nd_segy(path: str, grid_conf: GridConfig, segy_factory_conf: SegyFactoryConfig) -> SegySpec:
+    """Create a fake SEG-Y file with a multidimensional grid."""
+    spec = _segy_spec_mock_nd_segy(grid_conf, segy_factory_conf)
     factory = SegyFactory(spec=spec, samples_per_trace=segy_factory_conf.num_samples)
 
     dim_coords = ()
@@ -247,6 +250,8 @@ def generate_selection_mask(selection_conf: SelectionMaskConfig, grid_conf: Grid
 @pytest.fixture
 def export_masked_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Fixture that generates temp directory for export tests."""
+    if DEBUG_MODE:
+        return Path("TMP/export_masked")
     return tmp_path_factory.getbasetemp() / "export_masked"
 
 
@@ -261,7 +266,11 @@ class TestNdImportExport:
     """Test import/export of n-D SEG-Ys to MDIO, with and without selection mask."""
 
     def test_import(self, test_conf: MaskedExportConfig, export_masked_path: Path) -> None:
-        """Test import of an n-D SEG-Y file to MDIO."""
+        """Test import of an n-D SEG-Y file to MDIO.
+
+        NOTE: This test must be executed before running 'test_ingested_mdio', 'test_export', and
+        'test_export_masked' tests.
+        """
         grid_conf, segy_factory_conf, segy_to_mdio_conf, _ = test_conf
 
         domain = "Time"
@@ -298,14 +307,16 @@ class TestNdImportExport:
         )
 
     def test_ingested_mdio(self, test_conf: MaskedExportConfig, export_masked_path: Path) -> None:
-        """Verify if ingested data is correct."""
+        """Verify if ingested data is correct.
+
+        NOTE: This test must be executed after the 'test_import' successfully completes
+        and before running 'test_export' and 'test_export_masked' tests.
+        """
         grid_conf, segy_factory_conf, segy_to_mdio_conf, _ = test_conf
         mdio_path = export_masked_path / f"{grid_conf.name}.mdio"
 
         # Open the MDIO file
-        # NOTE: If mask_and_scale is not set,
-        # Xarray will convert int to float and replace _FillValue with NaN
-        ds = xr.open_dataset(mdio_path, engine="zarr", mask_and_scale=False)
+        ds = open_zarr_dataset(StorageLocation(str(mdio_path)))
 
         # Test dimensions and ingested dimension headers
         expected_dims = grid_conf.dims
@@ -353,56 +364,67 @@ class TestNdImportExport:
 
 
     def test_export(self, test_conf: MaskedExportConfig, export_masked_path: Path) -> None:
-        """Test export of an n-D MDIO file back to SEG-Y."""
+        """Test export of an n-D MDIO file back to SEG-Y.
+        
+        NOTE: This test must be executed after the 'test_import' and 'test_ingested_mdio' 
+        successfully complete.
+        """
         grid_conf, segy_factory_conf, segy_to_mdio_conf, _ = test_conf
 
         segy_path = export_masked_path / f"{grid_conf.name}.sgy"
         mdio_path = export_masked_path / f"{grid_conf.name}.mdio"
         segy_rt_path = export_masked_path / f"{grid_conf.name}_rt.sgy"
 
-        index_names = segy_factory_conf.header_byte_map.keys()
-        access_pattern = "".join(map(str, range(len(index_names) + 1)))
-        mdio = MDIOReader(mdio_path.__str__(), access_pattern=access_pattern)
-
-        chunks, shape = mdio.chunks, mdio.shape
-        new_chunks = segy_export_rechunker(chunks, shape, dtype="float32", limit="0.3M")
-
         mdio_to_segy(
-            mdio_path.__str__(),
-            segy_rt_path.__str__(),
-            access_pattern=access_pattern,
-            new_chunks=new_chunks,
+            segy_spec=_segy_spec_mock_nd_segy(grid_conf, segy_factory_conf),
+            input_location=StorageLocation(str(mdio_path)),
+            output_location=StorageLocation(str(segy_rt_path))
         )
 
         expected_sgy = SegyFile(segy_path)
         actual_sgy = SegyFile(segy_rt_path)
-        assert_array_equal(actual_sgy.trace[:], expected_sgy.trace[:])
+
+        num_traces = expected_sgy.num_traces
+        random_indices = np.random.choice(num_traces, 10, replace=False)
+        expected_traces = expected_sgy.trace[random_indices]
+        actual_traces = actual_sgy.trace[random_indices]
+
+        assert expected_sgy.num_traces == actual_sgy.num_traces
+        assert expected_sgy.text_header == actual_sgy.text_header
+        assert expected_sgy.binary_header == actual_sgy.binary_header
+
+        # TODO (Dmitriy Repin): Reconcile custom SegySpecs used in the roundtrip SEGY -> MDIO -> SEGY tests
+        # https://github.com/TGSAI/mdio-python/issues/610
+        assert_array_equal(desired=expected_traces.header, actual=actual_traces.header)
+        assert_array_equal(desired=expected_traces.sample, actual=actual_traces.sample)
+
 
     def test_export_masked(self, test_conf: MaskedExportConfig, export_masked_path: Path) -> None:
-        """Test export of an n-D MDIO file back to SEG-Y with masked export."""
+        """Test export of an n-D MDIO file back to SEG-Y with masked export.
+        
+        NOTE: This test must be executed after the 'test_import' and 'test_ingested_mdio' 
+        successfully complete.
+        """
         grid_conf, segy_factory_conf, segy_to_mdio_conf, selection_conf = test_conf
 
         segy_path = export_masked_path / f"{grid_conf.name}.sgy"
         mdio_path = export_masked_path / f"{grid_conf.name}.mdio"
         segy_rt_path = export_masked_path / f"{grid_conf.name}_rt.sgy"
 
-        index_names = segy_factory_conf.header_byte_map.keys()
-        access_pattern = "".join(map(str, range(len(index_names) + 1)))
-        mdio = MDIOReader(mdio_path.__str__(), access_pattern=access_pattern)
-        export_chunks = segy_export_rechunker(
-            mdio.chunks, mdio.shape, dtype="float32", limit="0.3M"
-        )
         selection_mask = generate_selection_mask(selection_conf, grid_conf)
 
         mdio_to_segy(
-            mdio_path.__str__(),
-            segy_rt_path.__str__(),
-            access_pattern=access_pattern,
-            new_chunks=export_chunks,
-            selection_mask=selection_mask,
+            segy_spec=_segy_spec_mock_nd_segy(grid_conf, segy_factory_conf),
+            input_location=StorageLocation(str(mdio_path)),
+            output_location=StorageLocation(str(segy_rt_path)),
+            selection_mask=selection_mask
         )
 
         expected_trc_idx = selection_mask.ravel().nonzero()[0]
         expected_sgy = SegyFile(segy_path)
         actual_sgy = SegyFile(segy_rt_path)
-        assert_array_equal(actual_sgy.trace[:], expected_sgy.trace[expected_trc_idx])
+
+        # TODO (Dmitriy Repin): Reconcile custom SegySpecs used in the roundtrip SEGY -> MDIO -> SEGY tests
+        # https://github.com/TGSAI/mdio-python/issues/610
+        assert_array_equal(actual_sgy.trace[:].header, expected_sgy.trace[expected_trc_idx].header)
+        assert_array_equal(actual_sgy.trace[:].sample, expected_sgy.trace[expected_trc_idx].sample)

--- a/tests/integration/testing_data.py
+++ b/tests/integration/testing_data.py
@@ -1,5 +1,38 @@
 """Integration tests data for teapot dome SEG-Y."""
 
+from segy.schema import SegySpec
+from segy.standards import get_segy_standard
+from tests.integration.testing_helpers import customize_segy_specs
+
+
+def custom_teapot_dome_segy_spec(keep_unaltered: bool) -> SegySpec:
+    """Return the minimum customized SEG-Y specification for the teapot dome dataset.
+
+    In SEG-Y spec rev 1.0:
+        inline                      = (189, "int32")
+        crossline                   = (193, "int32")
+        cdp_x                       = (181, "int32")
+        cdp_y                       = (185, "int32")
+    and
+        trace_num_orig_record       = (13, "int32")
+        energy_source_point_num     = (17, "int32")
+        group_coord_x               = (81, "int32")
+        group_coord_y               = (85, "int32")
+
+    In SEGY 1.0 - 2.1, the trace header contains unassigned bytes 181-240.
+    """
+    index_bytes: tuple[int, ...] = (17, 13, 81, 85)
+    index_names: tuple[str, ...] = ("inline", "crossline", "cdp_x", "cdp_y")
+    index_types: tuple[str, ...] = ("int32", "int32", "int32", "int32")
+    segy_spec = get_segy_standard(1.0)
+    return customize_segy_specs(
+        segy_spec=segy_spec,
+        index_bytes=index_bytes,
+        index_names=index_names,
+        index_types=index_types,
+        keep_unaltered = keep_unaltered
+    )
+
 
 def text_header_teapot_dome() -> list[str]:
     """Return the teapot dome expected text header."""

--- a/tests/integration/testing_helpers.py
+++ b/tests/integration/testing_helpers.py
@@ -74,8 +74,8 @@ def validate_variable(  # noqa PLR0913
         assert expected_names == actual_names
 
         # Compare field types
-        expected_types = [data_type[name] for name in data_type.names]
-        actual_types = [arr.dtype[name] for name in arr.dtype.names]
+        expected_types = [data_type[name].newbyteorder('=') for name in data_type.names]
+        actual_types = [arr.dtype[name].newbyteorder('=') for name in arr.dtype.names]
         assert expected_types == actual_types
 
         # Compare field offsets fails.

--- a/tests/unit/v1/converters/test_segy_to_mdio.py
+++ b/tests/unit/v1/converters/test_segy_to_mdio.py
@@ -1,0 +1,85 @@
+"""Tests for segY-to_mdio methods."""
+
+import numpy as np
+import xarray as xr
+from segy.arrays import HeaderArray as SegyHeaderArray
+
+from mdio.converters.segy import _populate_non_dim_coordinates
+from mdio.core.dimension import Dimension
+from mdio.core.grid import Grid
+
+
+def test__populate_non_dim_coordinates() -> None:
+    """Test population of non-dimensional coordinates."""
+    dim_in, dim_xl, dim_of, dim_az, dim_tm = 2, 3, 4, 5, 1
+    il = Dimension(name="inline", coords=np.arange(dim_in))
+    xl = Dimension(name="crossline", coords=np.arange(dim_xl))
+    of = Dimension(name="offset", coords=np.arange(dim_of))
+    az = Dimension(name="azimuth", coords=np.arange(dim_az))
+    tm = Dimension(name="time", coords=np.arange(dim_tm))
+
+    r = np.random.rand(dim_in, dim_xl, dim_of, dim_az)
+
+    il_, xl_, of_, az_ = np.meshgrid(il.coords, xl.coords, of.coords, az.coords, indexing="ij")
+    diff = 1000 * il_ + 100 * xl_ + 10 * of_ + 1 * az_  # Different values for the same (il, xl)
+    same = 1000 * il_ + 100 * xl_  # Same values for the same (il, xl)
+    near = 1000 * il_ + 100 * xl_ + 1e-09 * r  # Near same values for the same (il, xl)
+    # NOTE: near[1][1][1][1]: np.float64(1100.0000000003308)
+
+    data_type = [
+        ("inline", "<i4"),
+        ("crossline", "<i4"),
+        ("offset", "<i4"),
+        ("azimuth", "<i4"),
+        ("cdp_x", "<f8"),
+        ("cdp_y", "<f8"),
+        ("cdp_z", "<f8"),
+    ]
+    data_list = [
+        (i, j, k, m, diff[i, j, k, m], same[i, j, k, m], near[i, j, k, m])
+        for i in range(dim_in)
+        for j in range(dim_xl)
+        for k in range(dim_of)
+        for m in range(dim_az)
+    ]
+    segy_headers = SegyHeaderArray(np.array(data_list, dtype=data_type))
+
+    grid = Grid(dims=[il, xl, of, az, tm])
+    grid.build_map(segy_headers)
+
+    ds = xr.Dataset(
+        data_vars={
+            "amplitude": (
+                ["inline", "crossline", "offset", "azimuth", "time"],
+                np.zeros((dim_in, dim_xl, dim_of, dim_az, dim_tm), dtype=np.float32),
+            ),
+        },
+        coords={
+            # Define coordinates with their dimensions and values
+            "inline": il.coords,
+            "crossline": xl.coords,
+            "offset": of.coords,
+            "azimuth": az.coords,
+            "time": tm.coords,
+            "cdp_x": (["inline", "crossline"], np.zeros((dim_in, dim_xl), dtype=np.float64)),
+            "cdp_y": (["inline", "crossline"], np.zeros((dim_in, dim_xl), dtype=np.float64)),
+            "cdp_z": (["inline", "crossline"], np.zeros((dim_in, dim_xl), dtype=np.float64)),
+        },
+    )
+
+    coordinate_headers: dict[str, SegyHeaderArray] = {
+        "cdp_x": segy_headers["cdp_x"],
+        "cdp_y": segy_headers["cdp_y"],
+        "cdp_z": segy_headers["cdp_z"],
+    }
+
+    is_good, ds_populated, _ = _populate_non_dim_coordinates(ds, grid, coordinate_headers, [])
+
+    assert is_good["cdp_x"] is False
+    assert is_good["cdp_y"] is True
+    assert is_good["cdp_z"] is True
+    expected_values = np.array([[0.0, 100.0, 200.0], [1000.0, 1100.0, 1200.0]], dtype=np.float32)
+    assert np.allclose(ds_populated["cdp_x"].values, expected_values)
+    assert np.allclose(ds_populated["cdp_y"].values, expected_values)
+    assert np.allclose(ds_populated["cdp_z"].values, expected_values)
+    # NOTE: ds_populated['cdp_z'].values[1][1]: np.float64(1100.0000000008847)

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_coca.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_coca.py
@@ -116,7 +116,7 @@ class TestSeismic3DPreStackCocaTemplate:
         t = Seismic3DPreStackCocaTemplate(domain="time")
 
         # Template attributes
-        assert t._coord_dim_names == ["inline", "crossline", "offset", "azimuth"]
+        assert t._coord_dim_names == ["inline", "crossline"]
         assert t._dim_names == ["inline", "crossline", "offset", "azimuth", "time"]
         assert t._coord_names == ["cdp_x", "cdp_y"]
         assert t._var_chunk_shape == [8, 8, 32, 1, 1024]


### PR DESCRIPTION
No changes to segy_to_mdio logic

Created on top of
* [Enable PreStackCocaGathers3D - take two #616](https://github.com/TGSAI/mdio-python/pull/616)
* [Export MDIO v1 to SEGY #611](https://github.com/TGSAI/mdio-python/pull/611)
Those PRs need to be merged to v1 before reviewing this PR
