### PR TITLE
CLI 'import', 'copy', 'info' over v1

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -40,7 +40,7 @@ RUN uv venv $VIRTUAL_ENV
 # https://setuptools.pypa.io/en/latest/userguide/development_mode.html
 # This allows for live reloading of the code during development
 RUN uv pip install -e .
-# Install "extras" (development dependencies) in pyproject.toml
-RUN uv sync --group dev
+# Install optional cloud development dependencies in pyproject.toml
+RUN uv sync --extra cloud --group dev
 # Now one can run:
 #    pre-commit run --all-files

--- a/src/mdio/commands/copy.py
+++ b/src/mdio/commands/copy.py
@@ -64,9 +64,9 @@ def copy(  # noqa: PLR0913
     compatibility with various filesystems via FSSpec.
     """
     # Lazy import to reduce CLI startup time
-    from mdio.api.convenience import copy_mdio  # noqa: PLC0415
+    from mdio.converters.mdio import copy_mdio_cli  # noqa: PLC0415
 
-    copy_mdio(
+    copy_mdio_cli(
         source_mdio_path,
         target_mdio_path,
         overwrite,

--- a/src/mdio/commands/info.py
+++ b/src/mdio/commands/info.py
@@ -2,156 +2,33 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from typing import Any
 
+import xarray as xr
 from click import STRING
-from click import Choice
 from click import argument
 from click import command
 from click import option
-
-if TYPE_CHECKING:
-    from mdio import MDIOReader
-    from mdio.core import Grid
+from click_params import JSON
 
 
 @command(name="info")
 @argument("mdio-path", type=STRING)
 @option(
-    "-access",
-    "--access-pattern",
+    "-storage",
+    "--storage-options",
     required=False,
-    default="012",
-    help="Access pattern of the file",
-    type=STRING,
-    show_default=True,
+    help="Storage options for SEG-Y input file.",
+    type=JSON,
 )
-@option(
-    "-format",
-    "--output-format",
-    required=False,
-    default="pretty",
-    help="Output format. Pretty console or JSON.",
-    type=Choice(["pretty", "json"]),
-    show_default=True,
-    show_choices=True,
-)
-def info(mdio_path: str, output_format: str, access_pattern: str) -> None:
+def info(mdio_path: str, storage_options: dict[str, Any]) -> None:
     """Provide information on a MDIO dataset.
 
     By default, this returns human-readable information about the grid and stats for the dataset.
     If output-format is set to 'json' then a JSON is returned to facilitate parsing.
     """
-    # Lazy import to reduce CLI startup time
-    from mdio import MDIOReader  # noqa: PLC0415
-
-    reader = MDIOReader(mdio_path, access_pattern=access_pattern, return_metadata=True)
-
-    grid_dict = parse_grid(reader.grid)
-    stats_dict = cast_stats(reader.stats)
-    access_pattern_dict = parse_access_patterns(reader)
-
-    mdio_info = {
-        "path": mdio_path,
-        "stats": stats_dict,
-        "grid": grid_dict,
-        "access_patterns": access_pattern_dict,
-    }
-
-    if output_format == "pretty":
-        pretty_print(mdio_info)
-
-    if output_format == "json":
-        json_print(mdio_info)
-
-
-def cast_stats(stats_dict: dict[str, Any]) -> dict[str, float]:
-    """Normalize all floats to JSON serializable floats."""
-    return {k: float(v) for k, v in stats_dict.items()}
-
-
-def parse_grid(grid: Grid) -> dict[str, dict[str, int | str]]:
-    """Extract grid information per dimension."""
-    grid_dict = {}
-    for dim_name in grid.dim_names:
-        dim = grid.select_dim(dim_name)
-        min_ = str(dim.coords[0])
-        max_ = str(dim.coords[-1])
-        size = str(dim.coords.shape[0])
-        grid_dict[dim_name] = {"name": dim_name, "min": min_, "max": max_, "size": size}
-    return grid_dict
-
-
-def parse_access_patterns(reader: MDIOReader) -> dict[str, Any]:
-    """Extract access patterns and their info."""
-    access_pattern_dict = {}
-    for name, array in reader._data_group.arrays():
-        pattern = name.replace("chunked_", "")
-        chunks = str(array.chunks)
-        format_ = str(array.dtype)
-        compressors = str(array.compressors)
-        access_pattern_dict[pattern] = {
-            "chunks": chunks,
-            "format": format_,
-            "compressor(s)": compressors,
-        }
-
-    return access_pattern_dict
-
-
-def json_print(mdio_info: dict[str, Any]) -> None:
-    """Convert MDIO Info to JSON and pretty print."""
-    # Lazy import to reduce CLI startup time
-    from json import dumps as json_dumps  # noqa: PLC0415
-
-    from rich import print  # noqa: A004, PLC0415
-
-    print(json_dumps(mdio_info, indent=2))
-
-
-def pretty_print(mdio_info: dict[str, Any]) -> None:
-    """Print pretty MDIO Info table to console."""
-    # Lazy import to reduce CLI startup time
-    from rich.console import Console  # noqa: PLC0415
-    from rich.table import Table  # noqa: PLC0415
-
-    console = Console()
-
-    grid_table = Table(show_edge=False)
-    grid_table.add_column("Dimension", justify="right", style="cyan", no_wrap=True)
-    grid_table.add_column("Min", justify="left", style="magenta")
-    grid_table.add_column("Max", justify="left", style="magenta")
-    grid_table.add_column("Size", justify="left", style="green")
-
-    for axis_dict in mdio_info["grid"].values():
-        name, min_, max_, size = axis_dict.values()
-        grid_table.add_row(name, min_, max_, size)
-
-    stat_table = Table(show_edge=False)
-    stat_table.add_column("Stat", justify="right", style="cyan", no_wrap=True)
-    stat_table.add_column("Value", justify="left", style="magenta")
-
-    for stat, value in mdio_info["stats"].items():
-        stat_table.add_row(stat, f"{value:.4f}")
-
-    access_patter_table = Table(show_edge=False)
-    access_patter_table.add_column("Pattern", justify="right", style="cyan", no_wrap=True)
-    access_patter_table.add_column("Chunks", justify="left", style="magenta")
-    access_patter_table.add_column("Format", justify="left", style="magenta")
-    access_patter_table.add_column("Compressor", justify="left", style="magenta")
-
-    for name, pattern_info in mdio_info["access_patterns"].items():
-        chunks, format_, compressor = pattern_info.values()
-        access_patter_table.add_row(name, chunks, format_, compressor)
-
-    master_table = Table(title=f"File Information for {mdio_info['path']}")
-    master_table.add_column("Grid", justify="center")
-    master_table.add_column("Statistics", justify="center")
-    master_table.add_column("Access Patterns", justify="center")
-    master_table.add_row(grid_table, stat_table, access_patter_table)
-
-    console.print(master_table)
+    ds = xr.open_zarr(mdio_path, mask_and_scale=False, storage_options=storage_options)
+    print(ds)
 
 
 cli = info

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -452,6 +452,8 @@ def segy_to_mdio_cli(  # noqa PLR0913
         segy_spec = segy_spec.customize(trace_header_fields=index_fields)
 
     # Remove the following when grid overrides are implemented
+    # TODO(Dmitriy): implement grid overrides
+    # https://github.com/TGSAI/mdio-python/issues/585
     _ = grid_overrides
     segy_to_mdio(
         segy_spec=segy_spec,

--- a/src/mdio/core/storage_location.py
+++ b/src/mdio/core/storage_location.py
@@ -30,6 +30,9 @@ class StorageLocation:
         if uri.startswith(("s3://", "gs://")):
             return
 
+        if uri.startswith(("http://", "https://")):
+            return
+
         if uri.startswith("file://"):
             self._uri = self._uri.removeprefix("file://")
         # For local paths, ensure they are absolute and resolved

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,12 @@ def zarr_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="module")
+def mdio_copy_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Make a temp file for the copy of the MDIO. dataset."""
+    return tmp_path_factory.mktemp(r"mdio_copy")
+
+
+@pytest.fixture(scope="module")
 def zarr_tmp2(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the output MDIO."""
     return tmp_path_factory.mktemp(r"mdio2")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,9 +18,10 @@ def runner() -> CliRunner:
 @pytest.mark.dependency
 def test_main_succeeds(runner: CliRunner, segy_input: Path, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
-    cli_args = ["segy", "import", str(segy_input), str(zarr_tmp)]
-    cli_args.extend(["--header-locations", "181,185"])
-    cli_args.extend(["--header-names", "inline,crossline"])
+    cli_args = ["segy", "import", str(segy_input), str(zarr_tmp), "PostStack3DTime"]
+    cli_args.extend(["--header-locations", "17,13,81,85"])
+    cli_args.extend(["--header-names", "inline,crossline,cdp_x,cdp_y"])
+    cli_args.extend(["--overwrite"])
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0
@@ -30,9 +31,9 @@ def test_main_succeeds(runner: CliRunner, segy_input: Path, zarr_tmp: Path) -> N
 def test_main_cloud(runner: CliRunner, segy_input_uri: str, zarr_tmp: Path) -> None:
     """It exits with a status code of zero."""
     os.environ["MDIO__IMPORT__CLOUD_NATIVE"] = "true"
-    cli_args = ["segy", "import", segy_input_uri, str(zarr_tmp)]
-    cli_args.extend(["--header-locations", "181,185"])
-    cli_args.extend(["--header-names", "inline,crossline"])
+    cli_args = ["segy", "import", segy_input_uri, str(zarr_tmp), "PostStack3DTime"]
+    cli_args.extend(["--header-locations", "17,13,81,85"])
+    cli_args.extend(["--header-names", "inline,crossline,cdp_x,cdp_y"])
     cli_args.extend(["--overwrite"])
 
     result = runner.invoke(__main__.main, args=cli_args)
@@ -47,6 +48,29 @@ def test_main_info_succeeds(runner: CliRunner, zarr_tmp: Path) -> None:
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0
+    exp_output = """\
+<xarray.Dataset> Size: 392MB
+Dimensions:     (inline: 345, crossline: 188, time: 1501)
+Coordinates:
+    cdp_x       (inline, crossline) float64 519kB dask.array<chunksize=(345, 188), meta=np.ndarray>
+    cdp_y       (inline, crossline) float64 519kB dask.array<chunksize=(345, 188), meta=np.ndarray>
+  * crossline   (crossline) int32 752B 1 2 3 4 5 6 7 ... 183 184 185 186 187 188
+  * inline      (inline) int32 1kB 1 2 3 4 5 6 7 ... 339 340 341 342 343 344 345
+  * time        (time) int32 6kB 0 2 4 6 8 10 ... 2990 2992 2994 2996 2998 3000
+Data variables:
+    amplitude   (inline, crossline, time) float32 389MB dask.array<chunksize=(128, 128, 128), meta=np.ndarray>
+    headers     (inline, crossline) [('inline', '<i4'), ('crossline', '<i4'), ('cdp_x', '<i4'), ('cdp_y', '<i4')] 1MB dask.array<chunksize=(128, 128), meta=np.ndarray>
+    trace_mask  (inline, crossline) bool 65kB dask.array<chunksize=(345, 188), meta=np.ndarray>
+Attributes:
+    apiVersion:  1.0.0a1
+    createdOn:   2025-09-03 04:07:20.025836+00:00
+    name:        PostStack3DTime
+    attributes:  {'surveyDimensionality': '3D', 'ensembleType': 'line', 'proc...
+"""  # noqa: E501
+    # Remove the 'createdOn:' line that changes at every test run
+    expected = [item for item in exp_output.splitlines() if not item.startswith("    createdOn:")]
+    actual = [item for item in result.output.splitlines() if not item.startswith("    createdOn:")]
+    assert actual == expected
 
 
 @pytest.mark.dependency(depends=["test_main_succeeds"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,11 +75,18 @@ Attributes:
 
 @pytest.mark.dependency(depends=["test_main_succeeds"])
 def test_main_copy(runner: CliRunner, zarr_tmp: Path, zarr_tmp2: Path) -> None:
-    """It exits with a status code of zero."""
-    cli_args = ["copy", str(zarr_tmp), str(zarr_tmp2), "-headers", "-traces"]
+    """It exits with a status code of zero.
+
+    This tests depends on the test_main_succeeds to generate the input file
+    """
+    # We do not specify "-headers", "-traces" flags here,
+    # Thus, the dataset should be copied with FillValues in the traces and header.
+    cli_args = ["copy", str(zarr_tmp), str(zarr_tmp2), "--overwrite"]
 
     result = runner.invoke(__main__.main, args=cli_args)
     assert result.exit_code == 0
+    assert not Path(f"{zarr_tmp2}/amplitude/0.0.0").exists()
+    assert not Path(f"{zarr_tmp2}/headers/0.0").exists()
 
 
 def test_cli_version(runner: CliRunner) -> None:


### PR DESCRIPTION
Update to v1 the following CLI commands:

- mdio segy import segy-path mdio-path mdio-template-name
- mdio info mdio-path
- mdio copy mdio-source mdio-destination

<img width="437" height="673" alt="image" src="https://github.com/user-attachments/assets/f443d493-fd2c-4703-8de5-9bacb82b927e" />

The following will be implemented in a separate PRs:
- mdio copy source-mdio-path target-mdio-path
  - looks like non-trivial work requiring prioritization relative to other tasks
