### PR TITLE
Disaster recovery

### DIFF
--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import zarr
-from numcodecs import Blosc
+from numcodecs.zarr3 import Blosc
 from tqdm.auto import tqdm
 
 from mdio import MDIOReader
@@ -134,8 +134,8 @@ def create_rechunk_plan(
     metadata_arrs = []
     data_arrs = []
 
-    header_compressor = Blosc("zstd")
-    trace_compressor = Blosc("zstd") if compressors is None else compressors
+    header_compressor = Blosc(cname="zstd")
+    trace_compressor = Blosc(cname="zstd") if compressors is None else compressors
 
     for chunks, suffix in zip(chunks_list, suffix_list, strict=True):
         norm_chunks = tuple(min(chunk, size) for chunk, size in zip(chunks, source.shape, strict=True))

--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import zarr
-from numcodecs.zarr3 import Blosc
 from tqdm.auto import tqdm
+from zarr.codecs import BloscCodec
 
 from mdio import MDIOReader
 from mdio import MDIOWriter
@@ -134,8 +134,8 @@ def create_rechunk_plan(
     metadata_arrs = []
     data_arrs = []
 
-    header_compressor = Blosc(cname="zstd")
-    trace_compressor = Blosc(cname="zstd") if compressors is None else compressors
+    header_compressor = BloscCodec(cname="zstd")
+    trace_compressor = BloscCodec(cname="zstd") if compressors is None else compressors
 
     for chunks, suffix in zip(chunks_list, suffix_list, strict=True):
         norm_chunks = tuple(min(chunk, size) for chunk, size in zip(chunks, source.shape, strict=True))

--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -150,7 +150,7 @@ def create_rechunk_plan(
                 shape=metadata_array.shape,
                 dtype=metadata_array.dtype,
                 chunks=norm_chunks[:-1],
-                compressor=header_compressor,
+                compressors=header_compressor,
                 overwrite=overwrite,
             )
         )
@@ -161,7 +161,7 @@ def create_rechunk_plan(
                 shape=data_array.shape,
                 dtype=data_array.dtype,
                 chunks=norm_chunks,
-                compressor=trace_compressor,
+                compressors=trace_compressor,
                 overwrite=overwrite,
             )
         )

--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -145,7 +145,7 @@ def create_rechunk_plan(
             raise NameError(msg)
 
         metadata_arrs.append(
-            metadata_group.zeros(
+            metadata_group.create(
                 name=f"chunked_{suffix}_trace_headers",
                 shape=metadata_array.shape,
                 dtype=metadata_array.dtype,
@@ -156,7 +156,7 @@ def create_rechunk_plan(
         )
 
         data_arrs.append(
-            data_group.zeros(
+            data_group.create(
                 name=f"chunked_{suffix}",
                 shape=data_array.shape,
                 dtype=data_array.dtype,

--- a/src/mdio/api/convenience.py
+++ b/src/mdio/api/convenience.py
@@ -124,8 +124,6 @@ def create_rechunk_plan(
     Raises:
         NameError: if trying to write to original data.
     """
-    zarr.config.set({"write_empty_chunks": False})
-
     data_group = source._data_group
     metadata_group = source._metadata_group
 
@@ -154,8 +152,6 @@ def create_rechunk_plan(
                 chunks=norm_chunks[:-1],
                 compressor=header_compressor,
                 overwrite=overwrite,
-                zarr_format=2,
-                dimension_separator="/",
             )
         )
 
@@ -167,8 +163,6 @@ def create_rechunk_plan(
                 chunks=norm_chunks,
                 compressor=trace_compressor,
                 overwrite=overwrite,
-                zarr_format=2,
-                dimension_separator="/",
             )
         )
 

--- a/src/mdio/api/opener.py
+++ b/src/mdio/api/opener.py
@@ -29,7 +29,4 @@ def open_dataset(storage_location: StorageLocation, chunks: T_Chunks = None) -> 
     Returns:
         An Xarray dataset opened from the storage location.
     """
-    # NOTE: If mask_and_scale is not set,
-    # Xarray will convert int to float and replace _FillValue with NaN
-    # Fixed in Zarr v3, so we can fix this later.
-    return xr.open_dataset(storage_location.uri, engine="zarr", chunks=chunks, mask_and_scale=False)
+    return xr.open_dataset(storage_location.uri, engine="zarr", chunks=chunks)

--- a/src/mdio/constants.py
+++ b/src/mdio/constants.py
@@ -54,4 +54,5 @@ fill_value_map = {
     ScalarType.COMPLEX64: complex(np.nan, np.nan),
     ScalarType.COMPLEX128: complex(np.nan, np.nan),
     ScalarType.COMPLEX256: complex(np.nan, np.nan),
+    ScalarType.HEADERS: b"\x00" * 240,
 }

--- a/src/mdio/constants.py
+++ b/src/mdio/constants.py
@@ -1,50 +1,48 @@
 """Constant values used across MDIO."""
 
-from numpy import finfo as np_finfo
-from numpy import iinfo as np_iinfo
-from numpy import nan as np_nan
+import numpy as np
 
 from mdio.schemas.dtype import ScalarType
 
-FLOAT16_MAX = np_finfo("float16").max
-FLOAT16_MIN = np_finfo("float16").min
+FLOAT16_MAX = np.finfo("float16").max
+FLOAT16_MIN = np.finfo("float16").min
 
-FLOAT32_MAX = np_finfo("float32").max
-FLOAT32_MIN = np_finfo("float32").min
+FLOAT32_MAX = np.finfo("float32").max
+FLOAT32_MIN = np.finfo("float32").min
 
-FLOAT64_MIN = np_finfo("float64").min
-FLOAT64_MAX = np_finfo("float64").max
+FLOAT64_MIN = np.finfo("float64").min
+FLOAT64_MAX = np.finfo("float64").max
 
-INT8_MIN = np_iinfo("int8").min
-INT8_MAX = np_iinfo("int8").max
+INT8_MIN = np.iinfo("int8").min
+INT8_MAX = np.iinfo("int8").max
 
-INT16_MIN = np_iinfo("int16").min
-INT16_MAX = np_iinfo("int16").max
+INT16_MIN = np.iinfo("int16").min
+INT16_MAX = np.iinfo("int16").max
 
-INT32_MIN = np_iinfo("int32").min
-INT32_MAX = np_iinfo("int32").max
+INT32_MIN = np.iinfo("int32").min
+INT32_MAX = np.iinfo("int32").max
 
-INT64_MIN = np_iinfo("int64").min
-INT64_MAX = np_iinfo("int64").max
+INT64_MIN = np.iinfo("int64").min
+INT64_MAX = np.iinfo("int64").max
 
 UINT8_MIN = 0
-UINT8_MAX = np_iinfo("uint8").max
+UINT8_MAX = np.iinfo("uint8").max
 
 UINT16_MIN = 0
-UINT16_MAX = np_iinfo("uint16").max
+UINT16_MAX = np.iinfo("uint16").max
 
 UINT32_MIN = 0
-UINT32_MAX = np_iinfo("uint32").max
+UINT32_MAX = np.iinfo("uint32").max
 
 UINT64_MIN = 0
-UINT64_MAX = np_iinfo("uint64").max
+UINT64_MAX = np.iinfo("uint64").max
 
 # Zarr fill values for different scalar types
 fill_value_map = {
     ScalarType.BOOL: None,
-    ScalarType.FLOAT16: np_nan,
-    ScalarType.FLOAT32: np_nan,
-    ScalarType.FLOAT64: np_nan,
+    ScalarType.FLOAT16: np.nan,
+    ScalarType.FLOAT32: np.nan,
+    ScalarType.FLOAT64: np.nan,
     ScalarType.UINT8: UINT8_MAX,
     ScalarType.UINT16: UINT16_MAX,
     ScalarType.UINT32: UINT32_MAX,
@@ -53,7 +51,7 @@ fill_value_map = {
     ScalarType.INT16: INT16_MAX,
     ScalarType.INT32: INT32_MAX,
     ScalarType.INT64: INT64_MAX,
-    ScalarType.COMPLEX64: complex(np_nan, np_nan),
-    ScalarType.COMPLEX128: complex(np_nan, np_nan),
-    ScalarType.COMPLEX256: complex(np_nan, np_nan),
+    ScalarType.COMPLEX64: complex(np.nan, np.nan),
+    ScalarType.COMPLEX128: complex(np.nan, np.nan),
+    ScalarType.COMPLEX256: complex(np.nan, np.nan),
 }

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -405,6 +405,7 @@ def segy_to_mdio(
     headers = to_structured_type(segy_spec.trace.header.dtype)
 
     if os.getenv("MDIO__DO_RAW_HEADERS") == "1":
+        logger.warning("MDIO__DO_RAW_HEADERS is experimental and expected to change or be removed.")
         mdio_template = _add_raw_headers_to_template(mdio_template)
 
     horizontal_unit = _get_horizontal_coordinate_unit(segy_dimensions)

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -377,11 +377,11 @@ def segy_to_mdio(
     # blocked_io.to_zarr() -> _workers.trace_worker()
 
     # This will create the Zarr store with the correct structure but with empty arrays
-    xr_dataset.to_zarr(store=output_location.uri, mode="w", write_empty_chunks=False, zarr_format=2, compute=False)
+    xr_dataset.to_zarr(store=output_location.uri, mode="w", compute=False)
 
     # This will write the non-dimension coordinates and trace mask
     meta_ds = xr_dataset[drop_vars_delayed + ["trace_mask"]]
-    meta_ds.to_zarr(store=output_location.uri, mode="r+", write_empty_chunks=False, zarr_format=2, compute=True)
+    meta_ds.to_zarr(store=output_location.uri, mode="r+", compute=True)
 
     # Now we can drop them to simplify chunked write of the data variable
     xr_dataset = xr_dataset.drop_vars(drop_vars_delayed)

--- a/src/mdio/converters/type_converter.py
+++ b/src/mdio/converters/type_converter.py
@@ -78,6 +78,8 @@ def to_structured_type(data_type: np_dtype) -> StructuredType:
 def to_numpy_dtype(data_type: ScalarType | StructuredType) -> np_dtype:
     """Get the numpy dtype for a variable."""
     if isinstance(data_type, ScalarType):
+        if data_type == ScalarType.HEADERS:
+            return np_dtype("|V240")
         return np_dtype(data_type.value)
     if isinstance(data_type, StructuredType):
         return np_dtype([(f.name, f.format.value) for f in data_type.fields])

--- a/src/mdio/core/factory.py
+++ b/src/mdio/core/factory.py
@@ -119,8 +119,6 @@ def create_empty(
     Returns:
         Group: The root Zarr group representing the newly created MDIO dataset.
     """
-    zarr.config.set({"default_zarr_format": 2, "write_empty_chunks": False})
-
     url = process_url(url=config.path, disk_cache=False)
     root_group = open_group(url, mode="w", storage_options=storage_options)
     root_group = create_zarr_hierarchy(root_group, overwrite)
@@ -146,7 +144,6 @@ def create_empty(
         shape=live_shape,
         chunks=live_chunks,
         dtype="bool",
-        chunk_key_encoding={"name": "v2", "separator": "/"},
     )
 
     for variable in config.variables:
@@ -156,7 +153,6 @@ def create_empty(
             dtype=variable.dtype,
             compressors=variable.compressors,
             chunks=variable.chunks,
-            chunk_key_encoding={"name": "v2", "separator": "/"},
         )
 
         header_dtype = variable.header_dtype or DEFAULT_TRACE_HEADER_DTYPE
@@ -166,7 +162,6 @@ def create_empty(
             chunks=variable.chunks[:-1],  # Same spatial chunks as data
             compressors=Blosc("zstd"),
             dtype=header_dtype,
-            chunk_key_encoding={"name": "v2", "separator": "/"},
         )
 
     stats = {"mean": 0, "std": 0, "rms": 0, "min": 0, "max": 0}

--- a/src/mdio/core/factory.py
+++ b/src/mdio/core/factory.py
@@ -25,7 +25,7 @@ from importlib import metadata
 from typing import Any
 
 import zarr
-from numcodecs import Blosc
+from numcodecs.zarr3 import Blosc
 from numpy.typing import DTypeLike
 from zarr import Group
 from zarr import open_group
@@ -160,7 +160,7 @@ def create_empty(
             name=f"{variable.name}_trace_headers",
             shape=config.grid.shape[:-1],  # Same spatial shape as data
             chunks=variable.chunks[:-1],  # Same spatial chunks as data
-            compressors=Blosc("zstd"),
+            compressors=Blosc(cname="zstd"),
             dtype=header_dtype,
         )
 

--- a/src/mdio/core/factory.py
+++ b/src/mdio/core/factory.py
@@ -25,10 +25,10 @@ from importlib import metadata
 from typing import Any
 
 import zarr
-from numcodecs.zarr3 import Blosc
 from numpy.typing import DTypeLike
 from zarr import Group
 from zarr import open_group
+from zarr.codecs import BloscCodec
 from zarr.core.array import CompressorsLike
 
 from mdio.api.accessor import MDIOWriter
@@ -160,7 +160,7 @@ def create_empty(
             name=f"{variable.name}_trace_headers",
             shape=config.grid.shape[:-1],  # Same spatial shape as data
             chunks=variable.chunks[:-1],  # Same spatial chunks as data
-            compressors=Blosc(cname="zstd"),
+            compressors=BloscCodec(cname="zstd"),
             dtype=header_dtype,
         )
 

--- a/src/mdio/schemas/compressors.py
+++ b/src/mdio/schemas/compressors.py
@@ -7,51 +7,25 @@ Important Objects:
 
 from __future__ import annotations
 
-from enum import IntEnum
 from enum import StrEnum
 
 from pydantic import Field
 from pydantic import model_validator
+from zarr.codecs import BloscCname
+from zarr.codecs import BloscShuffle
 
 from mdio.schemas.core import CamelCaseStrictModel
-
-
-class BloscAlgorithm(StrEnum):
-    """Enum for Blosc algorithm options."""
-
-    BLOSCLZ = "blosclz"
-    LZ4 = "lz4"
-    LZ4HC = "lz4hc"
-    ZLIB = "zlib"
-    ZSTD = "zstd"
-
-
-class BloscShuffle(IntEnum):
-    """Enum for Blosc shuffle options."""
-
-    NOSHUFFLE = 0
-    SHUFFLE = 1
-    BITSHUFFLE = 2
-    AUTOSHUFFLE = -1
 
 
 class Blosc(CamelCaseStrictModel):
     """Data Model for Blosc options."""
 
     name: str = Field(default="blosc", description="Name of the compressor.")
-    algorithm: BloscAlgorithm = Field(
-        default=BloscAlgorithm.LZ4,
-        description="The Blosc compression algorithm to be used.",
-    )
-    level: int = Field(default=5, ge=0, le=9, description="The compression level.")
-    shuffle: BloscShuffle = Field(
-        default=BloscShuffle.SHUFFLE,
-        description="The shuffle strategy to be applied before compression.",
-    )
-    blocksize: int = Field(
-        default=0,
-        description="The size of the block to be used for compression.",
-    )
+    cname: BloscCname = Field(default=BloscCname.zstd, description="Compression algorithm name.")
+    clevel: int = Field(default=5, ge=0, le=9, description="Compression level (integer 0–9)")
+    shuffle: BloscShuffle | None = Field(default=None, description="Shuffling mode before compression.")
+    typesize: int | None = Field(default=None, description="The size in bytes that the shuffle is performed over.")
+    blocksize: int = Field(default=0, description="The size (in bytes) of blocks to divide data before compression.")
 
 
 zfp_mode_map = {

--- a/src/mdio/schemas/dtype.py
+++ b/src/mdio/schemas/dtype.py
@@ -32,6 +32,7 @@ class ScalarType(StrEnum):
     COMPLEX64 = "complex64"
     COMPLEX128 = "complex128"
     COMPLEX256 = "complex256"
+    HEADERS = "r1920"  # Raw number of BITS, must be a multiple of 8
 
 
 class StructuredField(CamelCaseStrictModel):

--- a/src/mdio/schemas/v1/dataset_serializer.py
+++ b/src/mdio/schemas/v1/dataset_serializer.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from dask import array as dask_array
-from numcodecs import Blosc as nc_Blosc
+from numcodecs.zarr3 import Blosc as nc_Blosc
 from xarray import DataArray as xr_DataArray
 from xarray import Dataset as xr_Dataset
 
@@ -127,7 +127,7 @@ def _convert_compressor(
 
     if isinstance(compressor, mdio_Blosc):
         return nc_Blosc(
-            cname=compressor.algorithm.value,
+            cname=compressor.algorithm,
             clevel=compressor.level,
             shuffle=compressor.shuffle.value,
             blocksize=compressor.blocksize if compressor.blocksize > 0 else 0,

--- a/src/mdio/schemas/v1/dataset_serializer.py
+++ b/src/mdio/schemas/v1/dataset_serializer.py
@@ -154,7 +154,8 @@ def _get_fill_value(data_type: ScalarType | StructuredType | str) -> any:
         return fill_value_map.get(data_type)
     if isinstance(data_type, StructuredType):
         numpy_dtype = to_numpy_dtype(data_type)
-        return np.void((), dtype=numpy_dtype)
+        fill_value = (0,) * len(numpy_dtype.fields)
+        return np.void(fill_value, dtype=numpy_dtype)
     if isinstance(data_type, str):
         return ""
     # If we do not have a fill value for this type, use None

--- a/src/mdio/schemas/v1/dataset_serializer.py
+++ b/src/mdio/schemas/v1/dataset_serializer.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 from dask import array as dask_array
-from numcodecs.zarr3 import Blosc as nc_Blosc
 from xarray import DataArray as xr_DataArray
 from xarray import Dataset as xr_Dataset
+from zarr.codecs import BloscCodec
 
 from mdio.converters.type_converter import to_numpy_dtype
 
@@ -120,18 +120,13 @@ def _get_zarr_chunks(var: Variable, all_named_dims: dict[str, NamedDimension]) -
 
 def _convert_compressor(
     compressor: mdio_Blosc | mdio_ZFP | None,
-) -> nc_Blosc | zfpy_ZFPY | None:
+) -> BloscCodec | zfpy_ZFPY | None:
     """Convert a compressor to a numcodecs compatible format."""
     if compressor is None:
         return None
 
     if isinstance(compressor, mdio_Blosc):
-        return nc_Blosc(
-            cname=compressor.algorithm,
-            clevel=compressor.level,
-            shuffle=compressor.shuffle.value,
-            blocksize=compressor.blocksize if compressor.blocksize > 0 else 0,
-        )
+        return BloscCodec(**compressor.model_dump(exclude={"name"}))
 
     if isinstance(compressor, mdio_ZFP):
         if zfpy_ZFPY is None:

--- a/src/mdio/schemas/v1/templates/abstract_dataset_template.py
+++ b/src/mdio/schemas/v1/templates/abstract_dataset_template.py
@@ -199,7 +199,7 @@ class AbstractDatasetTemplate(ABC):
             name="trace_mask",
             dimensions=self._dim_names[:-1],  # All dimensions except vertical (the last one)
             data_type=ScalarType.BOOL,
-            compressor=compressors.Blosc(algorithm=compressors.BloscAlgorithm.ZSTD),
+            compressor=compressors.Blosc(cname=compressors.BloscCname.zstd),  # also default in zarr3
             coordinates=self._coord_names,
             metadata_info=None,
         )
@@ -212,7 +212,7 @@ class AbstractDatasetTemplate(ABC):
             name="headers",
             dimensions=self._dim_names[:-1],  # All dimensions except vertical (the last one)
             data_type=headers,
-            compressor=compressors.Blosc(algorithm=compressors.BloscAlgorithm.ZSTD),
+            compressor=compressors.Blosc(cname=compressors.BloscCname.zstd),  # also default in zarr3
             coordinates=self._coord_names,
             metadata_info=[
                 ChunkGridMetadata(
@@ -231,7 +231,7 @@ class AbstractDatasetTemplate(ABC):
             name=self.default_variable_name,
             dimensions=self._dim_names,
             data_type=ScalarType.FLOAT32,
-            compressor=compressors.Blosc(algorithm=compressors.BloscAlgorithm.ZSTD),
+            compressor=compressors.Blosc(cname=compressors.BloscCname.zstd),  # also default in zarr3
             coordinates=self._coord_names,
             metadata_info=[
                 ChunkGridMetadata(

--- a/src/mdio/segy/_workers.py
+++ b/src/mdio/segy/_workers.py
@@ -160,7 +160,7 @@ def trace_worker(  # noqa: PLR0913
         encoding=ds_to_write[data_variable_name].encoding,  # Not strictly necessary, but safer than not doing it.
     )
 
-    ds_to_write.to_zarr(output_location.uri, region=region, mode="r+", write_empty_chunks=False, zarr_format=2)
+    ds_to_write.to_zarr(output_location.uri, region=region, mode="r+")
 
     histogram = CenteredBinHistogram(bin_centers=[], counts=[])
     return SummaryStatistics(

--- a/src/mdio/segy/_workers.py
+++ b/src/mdio/segy/_workers.py
@@ -122,12 +122,15 @@ def trace_worker(  # noqa: PLR0913
     traces = segy_file.trace[live_trace_indexes]
 
     header_key = "headers"
+    raw_header_key = "raw_headers"
 
     # Get subset of the dataset that has not yet been saved
     # The headers might not be present in the dataset
     worker_variables = [data_variable_name]
     if header_key in dataset.data_vars:  # Keeping the `if` here to allow for more worker configurations
         worker_variables.append(header_key)
+    if raw_header_key in dataset.data_vars:
+        worker_variables.append(raw_header_key)
 
     ds_to_write = dataset[worker_variables]
 
@@ -145,6 +148,15 @@ def trace_worker(  # noqa: PLR0913
             tmp_headers,
             attrs=ds_to_write[header_key].attrs,
             encoding=ds_to_write[header_key].encoding,  # Not strictly necessary, but safer than not doing it.
+        )
+    if raw_header_key in worker_variables:
+        tmp_raw_headers = np.zeros_like(dataset[raw_header_key])
+        tmp_raw_headers[not_null] = traces.header.view("|V240")
+        ds_to_write[raw_header_key] = Variable(
+            ds_to_write[raw_header_key].dims,
+            tmp_raw_headers,
+            attrs=ds_to_write[raw_header_key].attrs,
+            encoding=ds_to_write[raw_header_key].encoding,  # Not strictly necessary, but safer than not doing it.
         )
 
     data_variable = ds_to_write[data_variable_name]

--- a/src/mdio/segy/blocked_io.py
+++ b/src/mdio/segy/blocked_io.py
@@ -57,7 +57,7 @@ def to_zarr(  # noqa: PLR0913, PLR0915
     grid_map: zarr_Array,
     dataset: xr_Dataset,
     data_variable_name: str,
-) -> None:
+) -> SummaryStatistics:
     """Blocked I/O from SEG-Y to chunked `xarray.Dataset`.
 
     Args:

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -13,7 +13,7 @@ TEST_SCHEMA = {
             "name": "actual_variable",
             "data_type": "float32",
             "dimensions": ["dim0", "dim1"],
-            "compressor": {"name": "blosc", "level": 3},
+            "compressor": {"name": "blosc", "clevel": 3},
             "coordinates": ["coord"],
             "metadata": {
                 "chunk_grid": {

--- a/tests/unit/v1/converters/test_type_converter.py
+++ b/tests/unit/v1/converters/test_type_converter.py
@@ -1,7 +1,7 @@
 """Unit tests for the type converter module."""
 
+import numpy as np
 import pytest
-from numpy import dtype as np_dtype
 
 from mdio.converters.type_converter import to_numpy_dtype
 from mdio.converters.type_converter import to_scalar_type
@@ -58,19 +58,19 @@ def test_to_numpy_dtype(supported_scalar_types_map: tuple[ScalarType, str], a_st
     # Test 1: ScalarType cases - all supported scalar types
     for scalar_type, expected_numpy_type in supported_scalar_types_map:
         result = to_numpy_dtype(scalar_type)
-        expected = np_dtype(expected_numpy_type)
+        expected = np.dtype(expected_numpy_type)
         assert result == expected
-        assert isinstance(result, np_dtype)
+        assert isinstance(result, np.dtype)
         assert result.name == expected.name
 
     # Test 2: StructuredType with multiple fields
     result_multi = to_numpy_dtype(a_structured_type)
-    expected_multi = np_dtype(
+    expected_multi = np.dtype(
         [("x", "float64"), ("y", "float64"), ("z", "float64"), ("id", "int32"), ("valid", "bool")]
     )
 
     assert result_multi == expected_multi
-    assert isinstance(result_multi, np_dtype)
+    assert isinstance(result_multi, np.dtype)
     assert len(result_multi.names) == 5
     assert set(result_multi.names) == {"x", "y", "z", "id", "valid"}
 
@@ -78,14 +78,14 @@ def test_to_numpy_dtype(supported_scalar_types_map: tuple[ScalarType, str], a_st
 def test_to_scalar_type(supported_scalar_types_map: tuple[ScalarType, str]) -> None:
     """Test for to_scalar_type function."""
     for expected_mdio_type, numpy_type in supported_scalar_types_map:
-        result = to_scalar_type(np_dtype(numpy_type))
+        result = to_scalar_type(np.dtype(numpy_type))
         assert result == expected_mdio_type
 
 
 def test_to_structured_type(a_structured_type: StructuredType) -> None:
     """Test for to_structured_type function."""
-    dtype = np_dtype([("x", "float64"), ("y", "float64"), ("z", "float64"), ("id", "int32"), ("valid", "bool")])
+    dtype = np.dtype([("x", "float64"), ("y", "float64"), ("z", "float64"), ("id", "int32"), ("valid", "bool")])
     assert a_structured_type == to_structured_type(dtype)
 
-    dtype = np_dtype([("x", "<f8"), ("y", "<f8"), ("z", "<f8"), ("id", "<i4"), ("valid", "?")])
+    dtype = np.dtype([("x", "<f8"), ("y", "<f8"), ("z", "<f8"), ("id", "<i4"), ("valid", "?")])
     assert a_structured_type == to_structured_type(dtype)

--- a/tests/unit/v1/helpers.py
+++ b/tests/unit/v1/helpers.py
@@ -3,6 +3,7 @@
 from mdio.schemas.chunk_grid import RegularChunkGrid
 from mdio.schemas.chunk_grid import RegularChunkShape
 from mdio.schemas.compressors import Blosc
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.dtype import StructuredField
 from mdio.schemas.dtype import StructuredType
@@ -200,7 +201,7 @@ def make_seismic_poststack_3d_acceptance_dataset(dataset_name: str) -> Dataset:
         name="image",
         dimensions=["inline", "crossline", "depth"],
         data_type=ScalarType.FLOAT32,
-        compressor=Blosc(algorithm="zstd"),
+        compressor=Blosc(cname=BloscCname.zstd),  # also default in zarr3
         coordinates=["cdp_x", "cdp_y"],
         metadata_info=[
             ChunkGridMetadata(
@@ -238,7 +239,7 @@ def make_seismic_poststack_3d_acceptance_dataset(dataset_name: str) -> Dataset:
         long_name="inline optimized version of 3d_stack",
         dimensions=["inline", "crossline", "depth"],
         data_type=ScalarType.FLOAT32,
-        compressor=Blosc(algorithm="zstd"),
+        compressor=Blosc(cname=BloscCname.zstd),  # also default in zarr3
         coordinates=["cdp_x", "cdp_y"],
         metadata_info=[
             ChunkGridMetadata(chunk_grid=RegularChunkGrid(configuration=RegularChunkShape(chunk_shape=[4, 512, 512])))

--- a/tests/unit/v1/templates/test_seismic_3d_poststack.py
+++ b/tests/unit/v1/templates/test_seismic_3d_poststack.py
@@ -4,6 +4,7 @@ from tests.unit.v1.helpers import validate_variable
 
 from mdio.schemas.chunk_grid import RegularChunkGrid
 from mdio.schemas.compressors import Blosc
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.dtype import StructuredType
 from mdio.schemas.v1.dataset import Dataset
@@ -181,7 +182,7 @@ class TestSeismic3DPostStackTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [128, 128, 128]
         assert seismic.metadata.stats_v1 is None
@@ -214,7 +215,7 @@ class TestSeismic3DPostStackTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [128, 128, 128]
         assert seismic.metadata.stats_v1 is None

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_cdp.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_cdp.py
@@ -4,6 +4,7 @@ from tests.unit.v1.helpers import validate_variable
 
 from mdio.schemas.chunk_grid import RegularChunkGrid
 from mdio.schemas.compressors import Blosc
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.dtype import StructuredType
 from mdio.schemas.v1.dataset import Dataset
@@ -192,7 +193,7 @@ class TestSeismic3DPreStackCDPTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [1, 1, 512, 4096]
         assert seismic.metadata.stats_v1 is None
@@ -225,7 +226,7 @@ class TestSeismic3DPreStackCDPTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [1, 1, 512, 4096]
         assert seismic.metadata.stats_v1 is None

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_coca.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_coca.py
@@ -4,6 +4,7 @@ from tests.unit.v1.helpers import validate_variable
 
 from mdio.schemas.chunk_grid import RegularChunkGrid
 from mdio.schemas.compressors import Blosc
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.dtype import StructuredType
 from mdio.schemas.v1.dataset import Dataset
@@ -162,7 +163,7 @@ class TestSeismic3DPreStackCocaTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [8, 8, 32, 1, 1024]
         assert seismic.metadata.stats_v1 is None

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_shot.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_shot.py
@@ -4,6 +4,7 @@ from tests.unit.v1.helpers import validate_variable
 
 from mdio.schemas.chunk_grid import RegularChunkGrid
 from mdio.schemas.compressors import Blosc
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.dtype import StructuredType
 from mdio.schemas.v1.dataset import Dataset
@@ -218,7 +219,7 @@ class TestSeismic3DPreStackShotTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [1, 1, 512, 4096]
         assert seismic.metadata.stats_v1 is None
@@ -251,7 +252,7 @@ class TestSeismic3DPreStackShotTemplate:
             dtype=ScalarType.FLOAT32,
         )
         assert isinstance(seismic.compressor, Blosc)
-        assert seismic.compressor.algorithm == "zstd"
+        assert seismic.compressor.cname == BloscCname.zstd
         assert isinstance(seismic.metadata.chunk_grid, RegularChunkGrid)
         assert seismic.metadata.chunk_grid.configuration.chunk_shape == [1, 1, 512, 4096]
         assert seismic.metadata.stats_v1 is None

--- a/tests/unit/v1/test_dataset_builder_add_coordinate.py
+++ b/tests/unit/v1/test_dataset_builder_add_coordinate.py
@@ -1,6 +1,7 @@
 """Tests the schema v1 dataset_builder.add_coordinate() public API."""
 
 import pytest
+from zarr.codecs import BloscCname
 
 from mdio.schemas.compressors import Blosc
 from mdio.schemas.dtype import ScalarType
@@ -96,7 +97,7 @@ def test_coordinate_with_full_parameters() -> None:
         long_name="Common Depth Point",
         dimensions=["inline", "crossline"],
         data_type=ScalarType.FLOAT16,
-        compressor=Blosc(algorithm="zstd"),
+        compressor=Blosc(cname=BloscCname.zstd),
         metadata_info=[
             AllUnits(units_v1=LengthUnitModel(length=LengthUnitEnum.FOOT)),
             UserAttributes(attributes={"MGA": 51, "UnitSystem": "Imperial"}),
@@ -106,7 +107,7 @@ def test_coordinate_with_full_parameters() -> None:
     c = validate_coordinate(builder, name="cdp", dims=[("inline", 100), ("crossline", 200)], dtype=ScalarType.FLOAT16)
     assert c.long_name == "Common Depth Point"
     assert isinstance(c.compressor, Blosc)
-    assert c.compressor.algorithm == "zstd"
+    assert c.compressor.cname == BloscCname.zstd
     assert c.metadata.attributes["MGA"] == 51
     assert c.metadata.attributes["UnitSystem"] == "Imperial"
     assert c.metadata.units_v1.length == LengthUnitEnum.FOOT
@@ -118,7 +119,7 @@ def test_coordinate_with_full_parameters() -> None:
         dtype=ScalarType.FLOAT16,
     )
     assert isinstance(v.compressor, Blosc)
-    assert v.compressor.algorithm == "zstd"
+    assert v.compressor.cname == BloscCname.zstd
     assert isinstance(v.metadata, VariableMetadata)
     assert v.metadata.units_v1.length == LengthUnitEnum.FOOT
     assert v.metadata.attributes["MGA"] == 51

--- a/tests/unit/v1/test_dataset_builder_add_variable.py
+++ b/tests/unit/v1/test_dataset_builder_add_variable.py
@@ -5,6 +5,7 @@ import pytest
 from mdio.schemas.chunk_grid import RegularChunkGrid
 from mdio.schemas.chunk_grid import RegularChunkShape
 from mdio.schemas.compressors import Blosc
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.metadata import ChunkGridMetadata
 from mdio.schemas.metadata import UserAttributes
@@ -182,7 +183,7 @@ def test_add_variable_full_parameters() -> None:
         long_name="Amplitude (dimensionless)",
         dimensions=["inline", "crossline", "depth"],
         data_type=ScalarType.FLOAT32,
-        compressor=Blosc(algorithm="zstd"),
+        compressor=Blosc(cname=BloscCname.zstd),
         coordinates=["inline", "crossline", "depth", "cdp_x", "cdp_y"],
         metadata_info=[
             AllUnits(units_v1=LengthUnitModel(length=LengthUnitEnum.FOOT)),
@@ -210,7 +211,7 @@ def test_add_variable_full_parameters() -> None:
     )
     assert v.long_name == "Amplitude (dimensionless)"
     assert isinstance(v.compressor, Blosc)
-    assert v.compressor.algorithm == "zstd"
+    assert v.compressor.cname == BloscCname.zstd
     assert len(v.coordinates) == 5
     assert v.metadata.stats_v1.count == 100
     assert isinstance(v.metadata, VariableMetadata)

--- a/tests/unit/v1/test_dataset_builder_build.py
+++ b/tests/unit/v1/test_dataset_builder_build.py
@@ -1,5 +1,6 @@
 """Tests the schema v1 dataset_builder.build() public API."""
 
+from mdio.schemas.compressors import BloscCname
 from mdio.schemas.dtype import ScalarType
 from mdio.schemas.dtype import StructuredField
 from mdio.schemas.dtype import StructuredType
@@ -99,7 +100,7 @@ def test_build_seismic_poststack_3d_acceptance_dataset() -> None:  # noqa: PLR09
         dtype=ScalarType.FLOAT32,
     )
     assert image.metadata.units_v1 is None  # No units defined for image
-    assert image.compressor.algorithm == "zstd"
+    assert image.compressor.cname == BloscCname.zstd
     assert image.metadata.chunk_grid.configuration.chunk_shape == [128, 128, 128]
     assert image.metadata.stats_v1.count == 100
 
@@ -122,7 +123,7 @@ def test_build_seismic_poststack_3d_acceptance_dataset() -> None:  # noqa: PLR09
         dtype=ScalarType.FLOAT32,
     )
     assert image_inline.long_name == "inline optimized version of 3d_stack"
-    assert image_inline.compressor.algorithm == "zstd"
+    assert image_inline.compressor.cname == BloscCname.zstd
     assert image_inline.metadata.chunk_grid.configuration.chunk_shape == [4, 512, 512]
 
     # Verify image_headers variable

--- a/tests/unit/v1/test_dataset_serializer.py
+++ b/tests/unit/v1/test_dataset_serializer.py
@@ -325,7 +325,7 @@ def test_to_xarray_dataset(tmp_path: Path) -> None:
     xr_ds = to_xarray_dataset(dataset)
 
     file_path = output_path(tmp_path, f"{xr_ds.attrs['name']}", debugging=False)
-    xr_ds.to_zarr(store=file_path, mode="w", zarr_format=2, compute=False)
+    xr_ds.to_zarr(store=file_path, mode="w", compute=False)
 
 
 def test_seismic_poststack_3d_acceptance_to_xarray_dataset(tmp_path: Path) -> None:
@@ -335,7 +335,7 @@ def test_seismic_poststack_3d_acceptance_to_xarray_dataset(tmp_path: Path) -> No
     xr_ds = to_xarray_dataset(dataset)
 
     file_path = output_path(tmp_path, f"{xr_ds.attrs['name']}", debugging=False)
-    xr_ds.to_zarr(store=file_path, mode="w", zarr_format=2, compute=False)
+    xr_ds.to_zarr(store=file_path, mode="w", compute=False)
 
 
 @pytest.mark.skip(reason="Bug reproducer for the issue 582")
@@ -348,12 +348,7 @@ def test_buf_reproducer_dask_to_zarr(tmp_path: Path) -> None:
     dtype = np_dtype([("inline", "int32"), ("cdp_x", "float64")])
     dtype_fill_value = np_zeros((), dtype=dtype)
 
-    # Use '_FillValue' instead of 'fill_value'
-    # 'fill_value' is not a valid encoding key in Zarr v2
-    my_attr_encoding = {
-        "_FillValue": dtype_fill_value,
-        "chunk_key_encoding": {"name": "v2", "separator": "/"},
-    }
+    my_attr_encoding = {"fill_value": dtype_fill_value}
 
     # Create a dask array using the data type
     # Do not specify encoding as the array attribute
@@ -363,7 +358,7 @@ def test_buf_reproducer_dask_to_zarr(tmp_path: Path) -> None:
     # Specify encoding per array
     encoding = {"myattr": my_attr_encoding}
     file_path = output_path(tmp_path, "to_zarr/zarr_dask", debugging=False)
-    aa.to_zarr(file_path, mode="w", zarr_format=2, encoding=encoding, compute=False)
+    aa.to_zarr(file_path, mode="w", encoding=encoding, compute=False)
 
 
 def test_to_zarr_from_zarr_zeros_1(tmp_path: Path) -> None:
@@ -375,21 +370,16 @@ def test_to_zarr_from_zarr_zeros_1(tmp_path: Path) -> None:
     dtype = np_dtype([("inline", "int32"), ("cdp_x", "float64")])
     dtype_fill_value = np_zeros((), dtype=dtype)
 
-    # Use '_FillValue' instead of 'fill_value'
-    # 'fill_value' is not a valid encoding key in Zarr v2
-    my_attr_encoding = {
-        "_FillValue": dtype_fill_value,
-        "chunk_key_encoding": {"name": "v2", "separator": "/"},
-    }
+    my_attr_encoding = {"fill_value": dtype_fill_value}
 
     # Create a zarr array using the data type,
     # Specify encoding as the array attribute
-    data = zarr_zeros((36, 36), dtype=dtype, zarr_format=2)
+    data = zarr_zeros((36, 36), dtype=dtype)
     aa = xr_DataArray(name="myattr", data=data)
     aa.encoding = my_attr_encoding
 
     file_path = output_path(tmp_path, "to_zarr/zarr_zarr_zerros_1", debugging=False)
-    aa.to_zarr(file_path, mode="w", zarr_format=2, compute=False)
+    aa.to_zarr(file_path, mode="w", compute=False)
 
 
 def test_to_zarr_from_zarr_zeros_2(tmp_path: Path) -> None:
@@ -401,22 +391,17 @@ def test_to_zarr_from_zarr_zeros_2(tmp_path: Path) -> None:
     dtype = np_dtype([("inline", "int32"), ("cdp_x", "float64")])
     dtype_fill_value = np_zeros((), dtype=dtype)
 
-    # Use '_FillValue' instead of 'fill_value'
-    # 'fill_value' is not a valid encoding key in Zarr v2
-    my_attr_encoding = {
-        "_FillValue": dtype_fill_value,
-        "chunk_key_encoding": {"name": "v2", "separator": "/"},
-    }
+    my_attr_encoding = {"fill_value": dtype_fill_value}
 
     # Create a zarr array using the data type,
     # Do not specify encoding as the array attribute
-    data = zarr_zeros((36, 36), dtype=dtype, zarr_format=2)
+    data = zarr_zeros((36, 36), dtype=dtype)
     aa = xr_DataArray(name="myattr", data=data)
 
     file_path = output_path(tmp_path, "to_zarr/zarr_zarr_zerros_2", debugging=False)
     # Specify encoding per array
     encoding = {"myattr": my_attr_encoding}
-    aa.to_zarr(file_path, mode="w", zarr_format=2, encoding=encoding, compute=False)
+    aa.to_zarr(file_path, mode="w", encoding=encoding, compute=False)
 
 
 def test_to_zarr_from_np(tmp_path: Path) -> None:
@@ -425,12 +410,7 @@ def test_to_zarr_from_np(tmp_path: Path) -> None:
     dtype = np_dtype([("inline", "int32"), ("cdp_x", "float64")])
     dtype_fill_value = np_zeros((), dtype=dtype)
 
-    # Use '_FillValue' instead of 'fill_value'
-    # 'fill_value' is not a valid encoding key in Zarr v2
-    my_attr_encoding = {
-        "_FillValue": dtype_fill_value,
-        "chunk_key_encoding": {"name": "v2", "separator": "/"},
-    }
+    my_attr_encoding = {"fill_value": dtype_fill_value}
 
     # Create a zarr array using the data type
     # Do not specify encoding as the array attribute
@@ -440,4 +420,4 @@ def test_to_zarr_from_np(tmp_path: Path) -> None:
     file_path = output_path(tmp_path, "to_zarr/zarr_np", debugging=False)
     # Specify encoding per array
     encoding = {"myattr": my_attr_encoding}
-    aa.to_zarr(file_path, mode="w", zarr_format=2, encoding=encoding, compute=False)
+    aa.to_zarr(file_path, mode="w", encoding=encoding, compute=False)

--- a/tests/unit/v1/test_dataset_serializer.py
+++ b/tests/unit/v1/test_dataset_serializer.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from dask import array as dask_array
 from xarray import DataArray as xr_DataArray
 from zarr import zeros as zarr_zeros
 
@@ -321,29 +320,6 @@ def test_seismic_poststack_3d_acceptance_to_xarray_dataset(tmp_path: Path) -> No
 
     file_path = output_path(tmp_path, f"{xr_ds.attrs['name']}", debugging=False)
     xr_ds.to_zarr(store=file_path, mode="w", compute=False)
-
-
-@pytest.mark.skip(reason="Bug reproducer for the issue 582")
-def test_buf_reproducer_dask_to_zarr(tmp_path: Path) -> None:
-    """Bug reproducer for the issue https://github.com/TGSAI/mdio-python/issues/582."""
-    # TODO(Dmitriy Repin): Remove this test after the bug is fixed
-    # https://github.com/TGSAI/mdio-python/issues/582
-
-    # Create a data type and the fill value
-    dtype = np.dtype([("inline", "int32"), ("cdp_x", "float64")])
-    dtype_fill_value = np.zeros((), dtype=dtype)
-
-    my_attr_encoding = {"fill_value": dtype_fill_value}
-
-    # Create a dask array using the data type
-    # Do not specify encoding as the array attribute
-    data = dask_array.zeros((36,), dtype=dtype, chunks=(36,))
-    aa = xr_DataArray(name="myattr", data=data)
-
-    # Specify encoding per array
-    encoding = {"myattr": my_attr_encoding}
-    file_path = output_path(tmp_path, "to_zarr/zarr_dask", debugging=False)
-    aa.to_zarr(file_path, mode="w", encoding=encoding, compute=False)
 
 
 def test_to_zarr_from_zarr_zeros_1(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds an option to write the raw trace header data as it's own array.

Note: This implementation is for zarr v3 only, so merges into #630