### PR TITLE
Allow legacy Zarr (v2) support

### DIFF
--- a/src/mdio/constants.py
+++ b/src/mdio/constants.py
@@ -1,8 +1,18 @@
 """Constant values used across MDIO."""
 
+from enum import IntEnum
+
 import numpy as np
 
 from mdio.schemas.dtype import ScalarType
+
+
+class ZarrFormat(IntEnum):
+    """Zarr version enum."""
+
+    V2 = 2
+    V3 = 3
+
 
 FLOAT16_MAX = np.finfo("float16").max
 FLOAT16_MIN = np.finfo("float16").min

--- a/src/mdio/core/utils_write.py
+++ b/src/mdio/core/utils_write.py
@@ -7,23 +7,11 @@ from dask.array.rechunk import _balance_chunksizes
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
-    from zarr import Group
 
 
 MAX_SIZE_LIVE_MASK = 512 * 1024**2
 
 JsonSerializable = str | int | float | bool | None | dict[str, "JsonSerializable"] | list["JsonSerializable"]
-
-
-def write_attribute(name: str, attribute: JsonSerializable, zarr_group: "Group") -> None:
-    """Write a mappable to Zarr array or group attribute.
-
-    Args:
-        name: Name of the attribute.
-        attribute: Mapping to write. Must be JSON serializable.
-        zarr_group: Output group or array.
-    """
-    zarr_group.attrs[name] = attribute
 
 
 def get_constrained_chunksize(
@@ -45,7 +33,7 @@ def get_constrained_chunksize(
     return tuple(_balance_chunksizes(chunk)[0] for chunk in chunks)
 
 
-def get_live_mask_chunksize(shape: tuple[int, ...]) -> tuple[int]:
+def get_live_mask_chunksize(shape: tuple[int, ...]) -> tuple[int, ...]:
     """Given a live_mask shape, calculate the optimal write chunk size.
 
     Args:

--- a/src/mdio/segy/blocked_io.py
+++ b/src/mdio/segy/blocked_io.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
+import zarr
 from dask.array import Array
 from dask.array import map_blocks
 from psutil import cpu_count
@@ -17,6 +18,7 @@ from tqdm.auto import tqdm
 from zarr import open_group as zarr_open_group
 
 from mdio.api.io import _normalize_storage_options
+from mdio.constants import ZarrFormat
 from mdio.core.indexing import ChunkIterator
 from mdio.schemas.v1.stats import CenteredBinHistogram
 from mdio.schemas.v1.stats import SummaryStatistics
@@ -117,6 +119,9 @@ def to_zarr(  # noqa: PLR0913, PLR0915
     zarr_group = zarr_open_group(output_path.as_posix(), mode="a", storage_options=storage_options)
     attr_json = final_stats.model_dump_json()
     zarr_group[data_variable_name].attrs.update({"statsV1": attr_json})
+
+    if zarr.config.get("default_zarr_format") == ZarrFormat.V2:
+        zarr.consolidate_metadata(zarr_group.store)
 
     return final_stats
 


### PR DESCRIPTION
This PR allows users to set

`zarr.config.set({"default_zarr_version": 2})` to allow using old v2.

This feature will be deprecated when tensorstore supports v3 structs. Follow: https://github.com/google/tensorstore/issues/241