### PR TITLE
Resolve header packing and rename DatasetBuilder's `header` kwarg to `header_dtype` for clarity.

### DIFF
--- a/src/mdio/builder/templates/abstract_dataset_template.py
+++ b/src/mdio/builder/templates/abstract_dataset_template.py
@@ -46,7 +46,7 @@ class AbstractDatasetTemplate(ABC):
         name: str,
         sizes: tuple[int, ...],
         horizontal_coord_unit: LengthUnitModel,
-        headers: StructuredType = None,
+        header_dtype: StructuredType = None,
     ) -> Dataset:
         """Template method that builds the dataset.
 
@@ -54,7 +54,7 @@ class AbstractDatasetTemplate(ABC):
             name: The name of the dataset.
             sizes: The sizes of the dimensions.
             horizontal_coord_unit: The units for the horizontal coordinates.
-            headers: Optional structured headers for the dataset.
+            header_dtype: Optional structured headers for the dataset.
 
         Returns:
             Dataset: The constructed dataset
@@ -69,8 +69,8 @@ class AbstractDatasetTemplate(ABC):
         self._add_coordinates()
         self._add_variables()
         self._add_trace_mask()
-        if headers:
-            self._add_trace_headers(headers)
+        if header_dtype:
+            self._add_trace_headers(header_dtype)
         return self._builder.build()
 
     @property
@@ -184,7 +184,7 @@ class AbstractDatasetTemplate(ABC):
             coordinates=self._coord_names,
         )
 
-    def _add_trace_headers(self, headers: StructuredType) -> None:
+    def _add_trace_headers(self, header_dtype: StructuredType) -> None:
         """Add trace mask variables."""
         # headers = StructuredType.model_validate(header_fields)
 
@@ -192,7 +192,7 @@ class AbstractDatasetTemplate(ABC):
         self._builder.add_variable(
             name="headers",
             dimensions=self._dim_names[:-1],  # All dimensions except vertical (the last one)
-            data_type=headers,
+            data_type=header_dtype,
             compressor=compressors.Blosc(cname=compressors.BloscCname.zstd),  # also default in zarr3
             coordinates=self._coord_names,
             metadata=VariableMetadata(chunk_grid=chunk_grid),

--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -368,16 +368,13 @@ def segy_to_mdio(  # noqa PLR0913
     grid = _build_and_check_grid(segy_dimensions, segy_file, segy_headers)
 
     _, non_dim_coords = _get_coordinates(grid, segy_headers, mdio_template)
-    # TODO(Altay): Turn this dtype into packed representation
-    # https://github.com/TGSAI/mdio-python/issues/601
-    headers = to_structured_type(segy_spec.trace.header.dtype)
-
+    header_dtype = to_structured_type(segy_spec.trace.header.dtype)
     horizontal_unit = _get_horizontal_coordinate_unit(segy_dimensions)
     mdio_ds: Dataset = mdio_template.build_dataset(
         name=mdio_template.name,
         sizes=grid.shape,
         horizontal_coord_unit=horizontal_unit,
-        headers=headers,
+        header_dtype=header_dtype,
     )
 
     _add_segy_ingest_attributes(dataset=mdio_ds, segy_file=segy_file, grid_overrides=grid_overrides)

--- a/tests/unit/v1/templates/test_seismic_2d_poststack.py
+++ b/tests/unit/v1/templates/test_seismic_2d_poststack.py
@@ -108,7 +108,7 @@ class TestSeismic2DPostStackTemplate:
             "Seismic 2D Time Line 001",
             sizes=(2048, 4096),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         # Verify dataset metadata

--- a/tests/unit/v1/templates/test_seismic_2d_prestack_cdp.py
+++ b/tests/unit/v1/templates/test_seismic_2d_prestack_cdp.py
@@ -138,7 +138,7 @@ class TestSeismic2DPreStackCDPTemplate:
             "North Sea 2D Prestack",
             sizes=(512, 36, 1536),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         assert dataset.metadata.name == "North Sea 2D Prestack"

--- a/tests/unit/v1/templates/test_seismic_2d_prestack_shot.py
+++ b/tests/unit/v1/templates/test_seismic_2d_prestack_shot.py
@@ -147,7 +147,7 @@ class TestSeismic2DPreStackShotTemplate:
             "North Sea 2D Shot Time",
             sizes=(256, 24, 2048),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         assert dataset.metadata.name == "North Sea 2D Shot Time"

--- a/tests/unit/v1/templates/test_seismic_3d_poststack.py
+++ b/tests/unit/v1/templates/test_seismic_3d_poststack.py
@@ -126,7 +126,7 @@ class TestSeismic3DPostStackTemplate:
             "Seismic 3D",
             sizes=(256, 512, 1024),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         assert dataset.metadata.name == "Seismic 3D"

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_cdp.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_cdp.py
@@ -147,7 +147,7 @@ class TestSeismic3DPreStackCDPTemplate:
             "North Sea 3D Prestack",
             sizes=(512, 768, 36, 1536),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         assert dataset.metadata.name == "North Sea 3D Prestack"

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_coca.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_coca.py
@@ -142,7 +142,7 @@ class TestSeismic3DPreStackCocaTemplate:
             "Permian Basin 3D CDP Coca Gathers",
             sizes=(256, 256, 100, 6, 2048),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         assert dataset.metadata.name == "Permian Basin 3D CDP Coca Gathers"

--- a/tests/unit/v1/templates/test_seismic_3d_prestack_shot.py
+++ b/tests/unit/v1/templates/test_seismic_3d_prestack_shot.py
@@ -156,7 +156,7 @@ class TestSeismic3DPreStackShotTemplate:
             "North Sea 3D Shot Time",
             sizes=(256, 512, 24, 2048),
             horizontal_coord_unit=UNITS_METER,
-            headers=structured_headers,
+            header_dtype=structured_headers,
         )
 
         assert dataset.metadata.name == "North Sea 3D Shot Time"


### PR DESCRIPTION
closes #601 