### PR TITLE
fix Dockerfile.dev

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -10,7 +10,7 @@
 #  3. The project source code will be host-mounted at /workspaces/mdio-python
 ARG PYTHON_VERSION="3.13"
 ARG LINUX_DISTRO="bookworm"
-ARG UV_VERSION="0.6.11"
+ARG UV_VERSION="0.8.15"
 FROM mcr.microsoft.com/devcontainers/python:1-${PYTHON_VERSION}-${LINUX_DISTRO}
 
 ENV USERNAME="vscode"


### PR DESCRIPTION
Fix the .devcontainer\Dockerfile.dev in the 'main' brunch by rplacing the UV version number with `ARG UV_VERSION="0.8.15"`
**Explanation**:: the pyproject.toml was recently updated to require ">=0.8.15"