### PR TITLE
Fix chunk grid metadata exclusion

### DIFF
--- a/src/mdio/builder/xarray_builder.py
+++ b/src/mdio/builder/xarray_builder.py
@@ -211,7 +211,7 @@ def to_xarray_dataset(mdio_ds: Dataset) -> xr_Dataset:  # noqa: PLR0912
 
         # Add array attributes
         if v.metadata is not None:
-            metadata_dict = v.metadata.model_dump(exclude_none=True, exclude={"chunkGrid"})
+            metadata_dict = v.metadata.model_dump(exclude_none=True, exclude={"chunk_grid"})
             data_array.attrs.update(metadata_dict)
         if v.long_name:
             data_array.attrs["long_name"] = v.long_name


### PR DESCRIPTION
Dropping unwanted metadata entry with alias didn't work (maybe bug in Pydantic?). Using field name instead works.