### PR TITLE
create empty

### DIFF
--- a/src/mdio/converters/segy.py
+++ b/src/mdio/converters/segy.py
@@ -417,3 +417,61 @@ def segy_to_mdio(  # noqa PLR0913
         dataset=xr_dataset,
         data_variable_name=default_variable_name,
     )
+
+
+def create_empty_mdio(  # noqa PLR0913
+    segy_spec: SegySpec,
+    mdio_template: AbstractDatasetTemplate,
+    grid: Grid,
+    output_path: UPath | Path | str,
+    overwrite: bool = False,
+) -> None:
+    """A function that creates an empty MDIO v1 file with known dimensions.
+
+    Args:
+        segy_spec: The SEG-Y specification to use for trace headers.
+        mdio_template: The MDIO template to use to define the dataset structure.
+        grid: The grid specifying the dimensions of the MDIO file.
+        output_path: The universal path for the output MDIO v1 file.
+        overwrite: Whether to overwrite the output file if it already exists. Defaults to False.
+
+    Raises:
+        FileExistsError: If the output location already exists and overwrite is False.
+    """
+    output_path = _normalize_path(output_path)
+
+    if not overwrite and output_path.exists():
+        err = f"Output location '{output_path.as_posix()}' exists. Set `overwrite=True` if intended."
+        raise FileExistsError(err)
+
+    # Build the dataset structure using the template and grid
+    header_dtype = to_structured_type(segy_spec.trace.header.dtype)
+    horizontal_unit = _get_horizontal_coordinate_unit(grid.dims)
+    mdio_ds: Dataset = mdio_template.build_dataset(
+        name=mdio_template.name,
+        sizes=grid.shape,
+        horizontal_coord_unit=horizontal_unit,
+        header_dtype=header_dtype,
+    )
+
+    # Convert to xarray dataset
+    xr_dataset: xr_Dataset = to_xarray_dataset(mdio_ds=mdio_ds)
+
+    # Populate coordinates using the grid
+    # For empty datasets, we only populate dimension coordinates
+    drop_vars_delayed = []
+    dataset, drop_vars_delayed = populate_dim_coordinates(xr_dataset, grid, drop_vars_delayed=drop_vars_delayed)
+
+    # Set the trace mask to indicate all traces are live (since this is an empty dataset)
+    if grid.live_mask is not None:
+        dataset.trace_mask.data[:] = grid.live_mask
+    else:
+        # If live_mask is None, create a mask where all traces are live
+        dataset.trace_mask.data[:] = True
+
+    # Create the Zarr store with the correct structure but with empty arrays
+    to_mdio(dataset, output_path=output_path, mode="w", compute=False)
+
+    # Write the dimension coordinates and trace mask
+    meta_ds = dataset[drop_vars_delayed + ["trace_mask"]]
+    to_mdio(meta_ds, output_path=output_path, mode="r+", compute=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ warnings.filterwarnings(
 def fake_segy_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the fake SEG-Y files we are going to create."""
     if DEBUG_MODE:
-        return Path("TMP/fake_segy")
+        return Path("tmp/fake_segy")
     return tmp_path_factory.mktemp(r"fake_segy")
 
 
@@ -37,7 +37,7 @@ def segy_input_uri() -> str:
 def segy_input(segy_input_uri: str, tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Download teapot dome dataset for testing."""
     if DEBUG_MODE:
-        tmp_dir = Path("TMP/segy")
+        tmp_dir = Path("tmp/segy")
         tmp_dir.mkdir(parents=True, exist_ok=True)
     else:
         tmp_dir = tmp_path_factory.mktemp("segy")
@@ -50,7 +50,7 @@ def segy_input(segy_input_uri: str, tmp_path_factory: pytest.TempPathFactory) ->
 def zarr_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the output MDIO."""
     if DEBUG_MODE:
-        return Path("TMP/mdio")
+        return Path("tmp/mdio")
     return tmp_path_factory.mktemp(r"mdio")
 
 
@@ -58,7 +58,7 @@ def zarr_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def zarr_tmp2(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the output MDIO."""
     if DEBUG_MODE:
-        return Path("TMP/mdio2")
+        return Path("tmp/mdio2")
     return tmp_path_factory.mktemp(r"mdio2")
 
 
@@ -66,8 +66,16 @@ def zarr_tmp2(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def segy_export_tmp(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Make a temp file for the round-trip IBM SEG-Y."""
     if DEBUG_MODE:
-        tmp_dir = Path("TMP/segy")
+        tmp_dir = Path("tmp/segy")
         tmp_dir.mkdir(parents=True, exist_ok=True)
     else:
         tmp_dir = tmp_path_factory.mktemp("segy")
     return tmp_dir / "teapot_roundtrip.segy"
+
+
+@pytest.fixture(scope="class")
+def empty_mdio(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Make a temp file for empty MDIO testing."""
+    if DEBUG_MODE:
+        return Path("tmp/empty_mdio")
+    return tmp_path_factory.mktemp(r"empty_mdio")

--- a/tests/integration/test_create_empty_mdio.py
+++ b/tests/integration/test_create_empty_mdio.py
@@ -1,0 +1,122 @@
+"""Test for create_empty_mdio function."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+from segy.standards import get_segy_standard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from segy.schema import SegySpec
+from tests.integration.testing_helpers import get_values
+from tests.integration.testing_helpers import validate_variable
+
+from mdio import __version__
+from mdio.api.io import open_mdio
+from mdio.builder.template_registry import get_template
+from mdio.converters.segy import create_empty_mdio
+from mdio.core import Dimension
+from mdio.core import Grid
+
+
+class TestCreateEmptyPostStack3DTimeMdio:
+    """Tests for create_empty_mdio function."""
+
+    @pytest.fixture(scope="class")
+    def segy_spec(self) -> SegySpec:
+        """Return the SEG-Y specification for the test."""
+        return get_segy_standard(1.0)
+
+    @pytest.fixture(scope="class")
+    def empty_mdio_path(self, segy_spec: SegySpec, empty_mdio: Path) -> Path:
+        """Create a temporary empty MDIO file for testing.
+
+        This fixture is scoped to the class level, so it will be executed only once
+        and shared across all test methods in the class.
+        """
+        # Create the grid with the specified dimensions
+        grid = Grid(
+            dims=[
+                Dimension(name="inline", coords=range(100, 300, 1)),  # 100-300 with step 1
+                Dimension(name="crossline", coords=range(1000, 1600, 2)),  # 1000-1600 with step 2
+                Dimension(name="time", coords=range(0, 3000, 4)),  # 0-3 seconds 4ms sample rate
+            ]
+        )
+
+        mdio_template = get_template("PostStack3DTime")
+
+        # Call create_empty_mdio
+        create_empty_mdio(
+            segy_spec=segy_spec, 
+            mdio_template=mdio_template, 
+            grid=grid, 
+            output_path=empty_mdio, 
+            overwrite=True
+        )
+
+        return empty_mdio
+
+    def test_dataset_metadata(self, empty_mdio_path: Path) -> None:
+        """Test dataset metadata for empty MDIO file."""
+        ds = open_mdio(empty_mdio_path)
+
+        # Check basic metadata attributes
+        expected_attrs = {
+            "apiVersion": __version__,
+            "name": "PostStack3DTime",
+        }
+        actual_attrs_json = ds.attrs
+
+        # Compare one by one due to ever changing createdOn
+        for key, value in expected_attrs.items():
+            assert key in actual_attrs_json
+            if key == "createdOn":
+                assert actual_attrs_json[key] is not None
+            else:
+                assert actual_attrs_json[key] == value
+
+        # Check that createdOn exists
+        assert "createdOn" in actual_attrs_json
+        assert actual_attrs_json["createdOn"] is not None
+
+        # Validate template attributes
+        attributes = ds.attrs["attributes"]
+        assert attributes is not None
+        assert len(attributes) == 3
+        # Validate all attributes provided by the abstract template
+        assert attributes["defaultVariableName"] == "amplitude"
+        assert attributes["surveyType"] == "3D"
+        assert attributes["gatherType"] == "stacked"
+
+    def test_grid(self, empty_mdio_path: Path, segy_spec: SegySpec) -> None:
+        """Test grid validation for empty MDIO file."""
+        ds = open_mdio(empty_mdio_path)
+
+        # Check that the dataset has the expected shape
+        assert ds.sizes == {"inline": 200, "crossline": 300, "time": 750}
+
+        # Validate the dimension coordinate variables
+        validate_variable(ds, "inline", (200,), ("inline",), np.int32, range(100, 300), get_values)
+        validate_variable(ds, "crossline", (300,), ("crossline",), np.int32, range(1000, 1600, 2), get_values)
+        validate_variable(ds, "time", (750,), ("time",), np.int32, range(0, 3000, 4), get_values)
+
+        # Validate the non-dimensional coordinate variables (should be empty for empty dataset)
+        validate_variable(ds, "cdp_x", (200, 300), ("inline", "crossline"), np.float64, None, None)
+        validate_variable(ds, "cdp_y", (200, 300), ("inline", "crossline"), np.float64, None, None)
+
+        # Validate the headers (should be empty for empty dataset)
+        # Infer the dtype from segy_spec and ignore endianness
+        header_dtype = segy_spec.trace.header.dtype.newbyteorder("native")
+        validate_variable(ds, "headers", (200, 300), ("inline", "crossline"), header_dtype, None, None)
+
+        # Validate the trace mask (should be all True for empty dataset)
+        validate_variable(ds, "trace_mask", (200, 300), ("inline", "crossline"), np.bool_, None, None)
+        trace_mask = ds["trace_mask"].values
+        assert np.all(trace_mask), "All traces should be marked as live in empty dataset"
+
+        # Validate the amplitude data (should be empty)
+        validate_variable(ds, "amplitude", (200, 300, 750), ("inline", "crossline", "time"), np.float32, None, None)

--- a/tests/integration/test_segy_import_export_masked.py
+++ b/tests/integration/test_segy_import_export_masked.py
@@ -285,7 +285,7 @@ def generate_selection_mask(selection_conf: SelectionMaskConfig, grid_conf: Grid
 def export_masked_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Fixture that generates temp directory for export tests."""
     if DEBUG_MODE:
-        return Path("TMP/export_masked")
+        return Path("tmp/export_masked")
     return tmp_path_factory.getbasetemp() / "export_masked"
 
 


### PR DESCRIPTION
Add new API
```Python
def create_empty_mdio(  # noqa PLR0913
    segy_spec: SegySpec,
    mdio_template: AbstractDatasetTemplate,
    grid: Grid,
    output_path: UPath | Path | str,
    overwrite: bool = False,
) -> None:
    """A function that creates an empty MDIO v1 file with known dimensions.

    Args:
        segy_spec: The SEG-Y specification to use for trace headers.
        mdio_template: The MDIO template to use to define the dataset structure.
        grid: The grid specifying the dimensions of the MDIO file.
        output_path: The universal path for the output MDIO v1 file.
        overwrite: Whether to overwrite the output file if it already exists. Defaults to False.
```