### PR TITLE
Remove CalculateCable grid override

### DIFF
--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -257,7 +257,6 @@ def segy_import(  # noqa: PLR0913
         --header-names shot,cable,chan
         --header-types int32,None,int32
         --chunk-size 8,2,256,512
-        --grid-overrides '{"ChannelWrap": True, "ChannelsPerCable": 800}'
 
         \b
         No grid overrides are necessary for shot gathers with channel numbers and wrapped channels.

--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -257,8 +257,7 @@ def segy_import(  # noqa: PLR0913
         --header-names shot,cable,chan
         --header-types int32,None,int32
         --chunk-size 8,2,256,512
-        --grid-overrides '{"ChannelWrap": True, "ChannelsPerCable": 800,
-                           "CalculateCable": True}'
+        --grid-overrides '{"ChannelWrap": True, "ChannelsPerCable": 800}'
 
         \b
         If we do have cable numbers in the headers, but channels are still sequential (aka.

--- a/src/mdio/segy/geometry.py
+++ b/src/mdio/segy/geometry.py
@@ -374,9 +374,6 @@ class DuplicateIndex(GridOverrideCommand):
         if "ChannelWrap" in grid_overrides:
             raise GridOverrideIncompatibleError(self.name, "ChannelWrap")
 
-        if "CalculateCable" in grid_overrides:
-            raise GridOverrideIncompatibleError(self.name, "CalculateCable")
-
         if self.required_keys is not None:
             self.check_required_keys(index_headers)
         self.check_required_params(grid_overrides)
@@ -437,9 +434,6 @@ class AutoChannelWrap(GridOverrideCommand):
         if "ChannelWrap" in grid_overrides:
             raise GridOverrideIncompatibleError(self.name, "ChannelWrap")
 
-        if "CalculateCable" in grid_overrides:
-            raise GridOverrideIncompatibleError(self.name, "CalculateCable")
-
         self.check_required_keys(index_headers)
         self.check_required_params(grid_overrides)
 
@@ -489,34 +483,6 @@ class ChannelWrap(GridOverrideCommand):
 
         channels_per_cable = grid_overrides["ChannelsPerCable"]
         index_headers["channel"] = (index_headers["channel"] - 1) % channels_per_cable + 1
-
-        return index_headers
-
-
-class CalculateCable(GridOverrideCommand):
-    """Calculate cable numbers from unwrapped channels."""
-
-    required_keys = {"shot_point", "cable", "channel"}
-    required_parameters = {"ChannelsPerCable"}
-
-    def validate(self, index_headers: HeaderArray, grid_overrides: dict[str, bool | int]) -> None:
-        """Validate if this transform should run on the type of data."""
-        if "AutoChannelWrap" in grid_overrides:
-            raise GridOverrideIncompatibleError(self.name, "AutoCableChannel")
-
-        self.check_required_keys(index_headers)
-        self.check_required_params(grid_overrides)
-
-    def transform(
-        self,
-        index_headers: HeaderArray,
-        grid_overrides: dict[str, bool | int],
-    ) -> NDArray:
-        """Perform the grid transform."""
-        self.validate(index_headers, grid_overrides)
-
-        channels_per_cable = grid_overrides["ChannelsPerCable"]
-        index_headers["cable"] = (index_headers["channel"] - 1) // channels_per_cable + 1
 
         return index_headers
 
@@ -574,7 +540,6 @@ class GridOverrider:
         self.commands = {
             "AutoChannelWrap": AutoChannelWrap(),
             "AutoShotWrap": AutoShotWrap(),
-            "CalculateCable": CalculateCable(),
             "ChannelWrap": ChannelWrap(),
             "NonBinned": NonBinned(),
             "HasDuplicates": DuplicateIndex(),

--- a/src/mdio/segy/geometry.py
+++ b/src/mdio/segy/geometry.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.lib import recfunctions as rfn
 
-from mdio.segy.exceptions import GridOverrideIncompatibleError
 from mdio.segy.exceptions import GridOverrideKeysError
 from mdio.segy.exceptions import GridOverrideMissingParameterError
 from mdio.segy.exceptions import GridOverrideUnknownError

--- a/tests/unit/test_segy_grid_overrides.py
+++ b/tests/unit/test_segy_grid_overrides.py
@@ -131,22 +131,6 @@ class TestAutoGridOverrides:
 class TestStreamerGridOverrides:
     """Check grid overrides for shot data with streamer acquisition."""
 
-    def test_channel_wrap(self, mock_streamer_headers: dict[str, npt.NDArray]) -> None:
-        """Test the ChannelWrap command."""
-        index_names = ("shot_point", "cable", "channel")
-        grid_overrides = {"ChannelWrap": True, "ChannelsPerCable": len(RECEIVERS)}
-
-        new_headers, new_names, new_chunks = run_override(grid_overrides, index_names, mock_streamer_headers)
-
-        assert new_names == index_names
-        assert new_chunks is None
-
-        dims = get_dims(new_headers)
-
-        assert_array_equal(dims[0].coords, SHOTS)
-        assert_array_equal(dims[1].coords, CABLES)
-        assert_array_equal(dims[2].coords, RECEIVERS)
-
     def test_missing_param(self, mock_streamer_headers: dict[str, npt.NDArray]) -> None:
         """Test missing parameters for the commands."""
         index_names = ("shot_point", "cable", "channel")

--- a/tests/unit/test_segy_grid_overrides.py
+++ b/tests/unit/test_segy_grid_overrides.py
@@ -147,56 +147,6 @@ class TestStreamerGridOverrides:
         assert_array_equal(dims[1].coords, CABLES)
         assert_array_equal(dims[2].coords, RECEIVERS)
 
-    def test_calculate_cable(
-        self,
-        mock_streamer_headers: dict[str, npt.NDArray],
-    ) -> None:
-        """Test the CalculateCable command."""
-        index_names = ("shot_point", "cable", "channel")
-        grid_overrides = {"CalculateCable": True, "ChannelsPerCable": len(RECEIVERS)}
-
-        new_headers, new_names, new_chunks = run_override(grid_overrides, index_names, mock_streamer_headers)
-
-        assert new_names == index_names
-        assert new_chunks is None
-
-        dims = get_dims(new_headers)
-
-        # We need channels because unwrap isn't done here
-        channels = unique(mock_streamer_headers["channel"])
-
-        # We reset the cables to start from 1.
-        cables = arange(1, len(CABLES) + 1, dtype="uint32")
-
-        assert_array_equal(dims[0].coords, SHOTS)
-        assert_array_equal(dims[1].coords, cables)
-        assert_array_equal(dims[2].coords, channels)
-
-    def test_wrap_and_calc_cable(
-        self,
-        mock_streamer_headers: dict[str, npt.NDArray],
-    ) -> None:
-        """Test the combined ChannelWrap and CalculateCable commands."""
-        index_names = ("shot_point", "cable", "channel")
-        grid_overrides = {
-            "CalculateCable": True,
-            "ChannelWrap": True,
-            "ChannelsPerCable": len(RECEIVERS),
-        }
-
-        new_headers, new_names, new_chunks = run_override(grid_overrides, index_names, mock_streamer_headers)
-
-        assert new_names == index_names
-        assert new_chunks is None
-
-        dims = get_dims(new_headers)
-        # We reset the cables to start from 1.
-        cables = arange(1, len(CABLES) + 1, dtype="uint32")
-
-        assert_array_equal(dims[0].coords, SHOTS)
-        assert_array_equal(dims[1].coords, cables)
-        assert_array_equal(dims[2].coords, RECEIVERS)
-
     def test_missing_param(self, mock_streamer_headers: dict[str, npt.NDArray]) -> None:
         """Test missing parameters for the commands."""
         index_names = ("shot_point", "cable", "channel")
@@ -205,9 +155,6 @@ class TestStreamerGridOverrides:
 
         with pytest.raises(GridOverrideMissingParameterError):
             overrider.run(mock_streamer_headers, index_names, {"ChannelWrap": True}, chunksize)
-
-        with pytest.raises(GridOverrideMissingParameterError):
-            overrider.run(mock_streamer_headers, index_names, {"CalculateCable": True}, chunksize)
 
     def test_incompatible_overrides(
         self,
@@ -219,10 +166,6 @@ class TestStreamerGridOverrides:
         overrider = GridOverrider()
 
         grid_overrides = {"ChannelWrap": True, "AutoChannelWrap": True}
-        with pytest.raises(GridOverrideIncompatibleError):
-            overrider.run(mock_streamer_headers, index_names, grid_overrides, chunksize)
-
-        grid_overrides = {"CalculateCable": True, "AutoChannelWrap": True}
         with pytest.raises(GridOverrideIncompatibleError):
             overrider.run(mock_streamer_headers, index_names, grid_overrides, chunksize)
 

--- a/tests/unit/test_segy_grid_overrides.py
+++ b/tests/unit/test_segy_grid_overrides.py
@@ -14,8 +14,6 @@ from numpy import unique
 from numpy.testing import assert_array_equal
 
 from mdio.core import Dimension
-from mdio.segy.exceptions import GridOverrideIncompatibleError
-from mdio.segy.exceptions import GridOverrideMissingParameterError
 from mdio.segy.exceptions import GridOverrideUnknownError
 from mdio.segy.geometry import GridOverrider
 
@@ -130,21 +128,6 @@ class TestAutoGridOverrides:
 
 class TestStreamerGridOverrides:
     """Check grid overrides for shot data with streamer acquisition."""
-
-    def test_missing_param(self, mock_streamer_headers: dict[str, npt.NDArray]) -> None:
-        """Test missing parameters for the commands."""
-        index_names = ("shot_point", "cable", "channel")
-        chunksize = None
-        overrider = GridOverrider()
-
-    def test_incompatible_overrides(
-        self,
-        mock_streamer_headers: dict[str, npt.NDArray],
-    ) -> None:
-        """Test commands that can't be run together."""
-        index_names = ("shot_point", "cable", "channel")
-        chunksize = None
-        overrider = GridOverrider()
 
     def test_unknown_override(
         self,


### PR DESCRIPTION
Per #612 `CalculateCable` is no longer required. This PR removes associated source code, tests, and documentation regarding it.