### PR TITLE
Remove ChannelWrap grid override

### DIFF
--- a/src/mdio/commands/segy.py
+++ b/src/mdio/commands/segy.py
@@ -257,17 +257,8 @@ def segy_import(  # noqa: PLR0913
         --header-names shot,cable,chan
         --header-types int32,None,int32
         --chunk-size 8,2,256,512
-        --grid-overrides '{"ChannelWrap": True, "ChannelsPerCable": 800,
-                           "CalculateCable": True}'
+        --grid-overrides '{"CalculateCable": True}'
 
-        \b
-        If we do have cable numbers in the headers, but channels are still sequential (aka.
-        unwrapped), we can still ingest it like this.
-        --header-locations 9,213,13
-        --header-names shot,cable,chan
-        --header-types int32,int16,int32
-        --chunk-size 8,2,256,512
-        --grid-overrides '{"ChannelWrap":True, "ChannelsPerCable": 800}'
         \b
         No grid overrides are necessary for shot gathers with channel numbers and wrapped channels.
 

--- a/src/mdio/segy/geometry.py
+++ b/src/mdio/segy/geometry.py
@@ -371,9 +371,6 @@ class DuplicateIndex(GridOverrideCommand):
 
     def validate(self, index_headers: HeaderArray, grid_overrides: dict[str, bool | int]) -> None:
         """Validate if this transform should run on the type of data."""
-        if "ChannelWrap" in grid_overrides:
-            raise GridOverrideIncompatibleError(self.name, "ChannelWrap")
-
         if "CalculateCable" in grid_overrides:
             raise GridOverrideIncompatibleError(self.name, "CalculateCable")
 
@@ -434,9 +431,6 @@ class AutoChannelWrap(GridOverrideCommand):
 
     def validate(self, index_headers: HeaderArray, grid_overrides: dict[str, bool | int]) -> None:
         """Validate if this transform should run on the type of data."""
-        if "ChannelWrap" in grid_overrides:
-            raise GridOverrideIncompatibleError(self.name, "ChannelWrap")
-
         if "CalculateCable" in grid_overrides:
             raise GridOverrideIncompatibleError(self.name, "CalculateCable")
 
@@ -465,30 +459,6 @@ class AutoChannelWrap(GridOverrideCommand):
                 cc_min = cable_chan_min[idx]
 
                 index_headers["channel"][cable_idxs] = index_headers["channel"][cable_idxs] - cc_min + 1
-
-        return index_headers
-
-
-class ChannelWrap(GridOverrideCommand):
-    """Wrap channels to start from one at cable boundaries."""
-
-    required_keys = {"shot_point", "cable", "channel"}
-    required_parameters = {"ChannelsPerCable"}
-
-    def validate(self, index_headers: HeaderArray, grid_overrides: dict[str, bool | int]) -> None:
-        """Validate if this transform should run on the type of data."""
-        if "AutoChannelWrap" in grid_overrides:
-            raise GridOverrideIncompatibleError(self.name, "AutoCableChannel")
-
-        self.check_required_keys(index_headers)
-        self.check_required_params(grid_overrides)
-
-    def transform(self, index_headers: HeaderArray, grid_overrides: dict[str, bool | int]) -> NDArray:
-        """Perform the grid transform."""
-        self.validate(index_headers, grid_overrides)
-
-        channels_per_cable = grid_overrides["ChannelsPerCable"]
-        index_headers["channel"] = (index_headers["channel"] - 1) % channels_per_cable + 1
 
         return index_headers
 
@@ -575,7 +545,6 @@ class GridOverrider:
             "AutoChannelWrap": AutoChannelWrap(),
             "AutoShotWrap": AutoShotWrap(),
             "CalculateCable": CalculateCable(),
-            "ChannelWrap": ChannelWrap(),
             "NonBinned": NonBinned(),
             "HasDuplicates": DuplicateIndex(),
         }

--- a/tests/unit/test_segy_grid_overrides.py
+++ b/tests/unit/test_segy_grid_overrides.py
@@ -131,22 +131,6 @@ class TestAutoGridOverrides:
 class TestStreamerGridOverrides:
     """Check grid overrides for shot data with streamer acquisition."""
 
-    def test_channel_wrap(self, mock_streamer_headers: dict[str, npt.NDArray]) -> None:
-        """Test the ChannelWrap command."""
-        index_names = ("shot_point", "cable", "channel")
-        grid_overrides = {"ChannelWrap": True, "ChannelsPerCable": len(RECEIVERS)}
-
-        new_headers, new_names, new_chunks = run_override(grid_overrides, index_names, mock_streamer_headers)
-
-        assert new_names == index_names
-        assert new_chunks is None
-
-        dims = get_dims(new_headers)
-
-        assert_array_equal(dims[0].coords, SHOTS)
-        assert_array_equal(dims[1].coords, CABLES)
-        assert_array_equal(dims[2].coords, RECEIVERS)
-
     def test_calculate_cable(
         self,
         mock_streamer_headers: dict[str, npt.NDArray],
@@ -172,39 +156,11 @@ class TestStreamerGridOverrides:
         assert_array_equal(dims[1].coords, cables)
         assert_array_equal(dims[2].coords, channels)
 
-    def test_wrap_and_calc_cable(
-        self,
-        mock_streamer_headers: dict[str, npt.NDArray],
-    ) -> None:
-        """Test the combined ChannelWrap and CalculateCable commands."""
-        index_names = ("shot_point", "cable", "channel")
-        grid_overrides = {
-            "CalculateCable": True,
-            "ChannelWrap": True,
-            "ChannelsPerCable": len(RECEIVERS),
-        }
-
-        new_headers, new_names, new_chunks = run_override(grid_overrides, index_names, mock_streamer_headers)
-
-        assert new_names == index_names
-        assert new_chunks is None
-
-        dims = get_dims(new_headers)
-        # We reset the cables to start from 1.
-        cables = arange(1, len(CABLES) + 1, dtype="uint32")
-
-        assert_array_equal(dims[0].coords, SHOTS)
-        assert_array_equal(dims[1].coords, cables)
-        assert_array_equal(dims[2].coords, RECEIVERS)
-
     def test_missing_param(self, mock_streamer_headers: dict[str, npt.NDArray]) -> None:
         """Test missing parameters for the commands."""
         index_names = ("shot_point", "cable", "channel")
         chunksize = None
         overrider = GridOverrider()
-
-        with pytest.raises(GridOverrideMissingParameterError):
-            overrider.run(mock_streamer_headers, index_names, {"ChannelWrap": True}, chunksize)
 
         with pytest.raises(GridOverrideMissingParameterError):
             overrider.run(mock_streamer_headers, index_names, {"CalculateCable": True}, chunksize)
@@ -217,10 +173,6 @@ class TestStreamerGridOverrides:
         index_names = ("shot_point", "cable", "channel")
         chunksize = None
         overrider = GridOverrider()
-
-        grid_overrides = {"ChannelWrap": True, "AutoChannelWrap": True}
-        with pytest.raises(GridOverrideIncompatibleError):
-            overrider.run(mock_streamer_headers, index_names, grid_overrides, chunksize)
 
         grid_overrides = {"CalculateCable": True, "AutoChannelWrap": True}
         with pytest.raises(GridOverrideIncompatibleError):


### PR DESCRIPTION
Per #612 `ChannelWrap` is no longer required. This PR removes associated source code, tests, and documentation regarding it.