### PR TITLE
Implement full-dimension chunking support in Templates

### DIFF
--- a/tests/unit/v1/templates/test_seismic_templates.py
+++ b/tests/unit/v1/templates/test_seismic_templates.py
@@ -23,8 +23,48 @@ class TestSeismicTemplates:
         template = Seismic2DPostStackTemplate("time")
         template.build_dataset("test", (50, 50))
 
-        with pytest.raises(ValueError, match="Chunk shape.*does not match dimension sizes"):
+        with pytest.raises(ValueError, match="Chunk shape.*has.*dimensions, expected"):
             template.full_chunk_shape = (32, 32, 32)
+
+    def test_chunk_shape_with_minus_one_before_build(self) -> None:
+        """Test that chunk shape can be set with -1 before build_dataset."""
+        template = Seismic2DPostStackTemplate("time")
+
+        # Should be able to set chunk shape with -1 before build_dataset
+        template.full_chunk_shape = (32, -1)
+
+        # Before build_dataset, getter should return unexpanded values
+        assert template.full_chunk_shape == (32, -1)
+        assert template._var_chunk_shape == (32, -1)
+
+    def test_chunk_shape_with_minus_one_after_build(self) -> None:
+        """Test that -1 values are expanded after build_dataset."""
+        template = Seismic2DPostStackTemplate("time")
+        template.full_chunk_shape = (32, -1)
+
+        # Build dataset with specific sizes
+        template.build_dataset("test", (100, 200))
+
+        # After build_dataset, getter should expand -1 to dimension size
+        assert template.full_chunk_shape == (32, 200)
+        assert template._var_chunk_shape == (32, -1)  # Internal storage unchanged
+
+    def test_chunk_shape_validation_invalid_values(self) -> None:
+        """Test that chunk shape setter rejects invalid values."""
+        template = Seismic2DPostStackTemplate("time")
+        template.build_dataset("test", (50, 50))
+
+        # Test rejection of 0
+        with pytest.raises(ValueError, match="Chunk size must be positive integer or -1"):
+            template.full_chunk_shape = (32, 0)
+
+        # Test rejection of negative values other than -1
+        with pytest.raises(ValueError, match="Chunk size must be positive integer or -1"):
+            template.full_chunk_shape = (32, -2)
+
+        # Test that positive values and -1 are accepted
+        template.full_chunk_shape = (32, -1)  # Should not raise
+        template.full_chunk_shape = (32, 16)  # Should not raise
 
     def test_all_templates_inherit_from_abstract(self) -> None:
         """Test that all concrete templates inherit from AbstractDatasetTemplate."""


### PR DESCRIPTION
Resolves #626 by applying appropriate logic.

Tested that code below sets the `amplitude` Variable chunk size to `(64, 64, 1501)` where 1501 is discovered at runtime.

```python
if __name__ == "__main__":
    from mdio import segy_to_mdio
    from segy.schema import HeaderField, ScalarType
    from segy.standards import get_segy_standard
    from mdio.builder.template_registry import get_template
    import os

    os.environ["MDIO__IMPORT__SAVE_SEGY_FILE_HEADER"] = "1"
    os.environ["MDIO__IMPORT__CPU_COUNT"] = "16"

    input_segy = "filt_mig.sgy"
    output_mdio = "filt_mig.mdio"

    input_spec = get_segy_standard(1)
    input_fields = [
        HeaderField(name="inline", byte=17, format=ScalarType.INT32),
        HeaderField(name="crossline", byte=13, format=ScalarType.INT32),
        HeaderField(name="cdp_x", byte=81, format=ScalarType.INT32),
        HeaderField(name="cdp_y", byte=85, format=ScalarType.INT32),
    ]
    input_spec = input_spec.customize(trace_header_fields=input_fields)

    template = get_template("PostStack3DTime")
    template.full_chunk_shape = (64, 64, -1)

    segy_to_mdio(
        segy_spec=input_spec,
        mdio_template=template,
        input_path=input_segy,
        output_path=output_mdio,
        overwrite=True,
    )
```