### PR TITLE
Fix nox venv reuse issue

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,7 @@ package = "mdio"
 python_versions = ["3.13", "3.12", "3.11"]
 nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv"
+nox.options.reuse_venv = "yes"
 nox.options.sessions = ("pre-commit", "safety", "mypy", "tests", "typeguard", "xdoctest", "docs-build")
 
 


### PR DESCRIPTION
Command `nox -s tests-3.13` would generate the below error if the nox environment already existed.

```bash
nox > Running session tests-3.13
nox > Creating virtual environment (uv) using python3.13 in .nox/tests-3-13
nox > Command uv venv -p python3.13 /home/source/mdio-python/.nox/tests-3-13 failed with exit code 2:
nox > Using CPython 3.13.9
Creating virtual environment at: .nox/tests-3-13
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at `/home/source/mdio-python/.nox/tests-3-13`. Use `--clear` to replace it

nox > Session tests-3.13 failed.
```