### PR TITLE
Add upper limit of zarr version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "universal-pathlib>=0.3.3",
     "xarray>=2025.10.1",
-    "zarr>=3.1.3",
+    "zarr>=3.1.3,<=3.1.6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Pending PyPi release for feature: https://github.com/zarr-developers/zarr-python/pull/3781

This PR will either be merged tomorrow if no release or closed and minimum version be set to `>3.1.6` if a new wheel becomes available.