### PR TITLE
Remove `shot_index` from `ReceiverGathers3D` template

### DIFF
--- a/src/mdio/builder/templates/seismic_3d_receiver_gathers.py
+++ b/src/mdio/builder/templates/seismic_3d_receiver_gathers.py
@@ -11,20 +11,19 @@ from mdio.builder.templates.types import DimCoordinateTypes
 
 
 class Seismic3DReceiverGathersTemplate(AbstractDatasetTemplate):
-    """Seismic 3D receiver gathers template with calculated shot index."""
+    """Seismic 3D receiver gathers template."""
 
     def __init__(self) -> None:
         super().__init__(data_domain="time")
 
-        self._dim_names = ("receiver", "shot_line", "shot_index", "time")
-        self._calculated_dims = ("shot_index",)
+        self._dim_names = ("receiver", "shot_line", "shot_point", "time")
         self._physical_coord_names = (
             "receiver_x",
             "receiver_y",
             "source_coord_x",
             "source_coord_y",
         )
-        self._logical_coord_names = ("shot_point",)
+        self._logical_coord_names = ()
         self._var_chunk_shape = (1, 1, 512, 4096)
 
     @property
@@ -37,11 +36,10 @@ class Seismic3DReceiverGathersTemplate(AbstractDatasetTemplate):
     def declare_coordinate_specs(self) -> tuple[CoordinateSpec, ...]:
         """Declare receiver- and shot-indexed coordinates for the 3D receiver gathers template."""
         receiver_dim = ("receiver",)
-        shot_dims = ("shot_line", "shot_index")
+        shot_dims = ("shot_line", "shot_point")
         return (
             CoordinateSpec(name="receiver_x", dimensions=receiver_dim, dtype=ScalarType.FLOAT64),
             CoordinateSpec(name="receiver_y", dimensions=receiver_dim, dtype=ScalarType.FLOAT64),
-            CoordinateSpec(name="shot_point", dimensions=shot_dims, dtype=ScalarType.UINT32),
             CoordinateSpec(name="source_coord_x", dimensions=shot_dims, dtype=ScalarType.FLOAT64),
             CoordinateSpec(name="source_coord_y", dimensions=shot_dims, dtype=ScalarType.FLOAT64),
         )
@@ -51,12 +49,12 @@ class Seismic3DReceiverGathersTemplate(AbstractDatasetTemplate):
         return {
             "receiver": ScalarType.UINT32,
             "shot_line": ScalarType.UINT32,
+            "shot_point": ScalarType.UINT32,
             self._data_domain: ScalarType.INT32,
         }
 
     def _add_coordinates(self) -> None:
         # Add dimension coordinates
-        # Note: shot_index is calculated (0-N), so we don't add a coordinate for it
         self._builder.add_coordinate(
             "receiver",
             dimensions=("receiver",),
@@ -68,6 +66,12 @@ class Seismic3DReceiverGathersTemplate(AbstractDatasetTemplate):
             dimensions=("shot_line",),
             data_type=self._dim_dtype("shot_line"),
             metadata=CoordinateMetadata(units_v1=self.get_unit_by_key("shot_line")),
+        )
+        self._builder.add_coordinate(
+            "shot_point",
+            dimensions=("shot_point",),
+            data_type=self._dim_dtype("shot_point"),
+            metadata=CoordinateMetadata(units_v1=self.get_unit_by_key("shot_point")),
         )
         self._builder.add_coordinate(
             self.trace_domain,
@@ -95,26 +99,17 @@ class Seismic3DReceiverGathersTemplate(AbstractDatasetTemplate):
             metadata=CoordinateMetadata(units_v1=self.get_unit_by_key("receiver_y")),
         )
 
-        # Shot point coordinate (actual shot point numbers, varies by shot_line and shot_index)
-        self._builder.add_coordinate(
-            "shot_point",
-            dimensions=("shot_line", "shot_index"),
-            data_type=ScalarType.UINT32,
-            compressor=compressor,
-            metadata=CoordinateMetadata(units_v1=self.get_unit_by_key("shot_point")),
-        )
-
-        # Source coordinates (vary by shot_line and shot_index)
+        # Source coordinates (vary by shot_line and shot_point)
         self._builder.add_coordinate(
             "source_coord_x",
-            dimensions=("shot_line", "shot_index"),
+            dimensions=("shot_line", "shot_point"),
             data_type=ScalarType.FLOAT64,
             compressor=compressor,
             metadata=CoordinateMetadata(units_v1=self.get_unit_by_key("source_coord_x")),
         )
         self._builder.add_coordinate(
             "source_coord_y",
-            dimensions=("shot_line", "shot_index"),
+            dimensions=("shot_line", "shot_point"),
             data_type=ScalarType.FLOAT64,
             compressor=compressor,
             metadata=CoordinateMetadata(units_v1=self.get_unit_by_key("source_coord_y")),

--- a/tests/unit/v1/templates/test_seismic_3d_receiver_gathers.py
+++ b/tests/unit/v1/templates/test_seismic_3d_receiver_gathers.py
@@ -21,20 +21,24 @@ UNITS_SECOND = TimeUnitModel(time=TimeUnitEnum.SECOND)
 EXPECTED_COORDINATES = [
     "receiver_x",
     "receiver_y",
-    "shot_point",
     "source_coord_x",
     "source_coord_y",
 ]
 
-DATASET_SIZE_MAP = {"receiver": 100, "shot_line": 10, "shot_index": 500, "time": 2048}
+DATASET_SIZE_MAP = {"receiver": 100, "shot_line": 10, "shot_point": 500, "time": 2048}
 
 
 def _validate_coordinates_headers_trace_mask(dataset: Dataset, headers: StructuredType) -> None:
     """Validate the coordinate, headers, trace_mask variables in the dataset."""
-    dataset_dtype_map = {"receiver": "uint32", "shot_line": "uint32", "time": "int32"}
+    dataset_dtype_map = {
+        "receiver": "uint32",
+        "shot_line": "uint32",
+        "shot_point": "uint32",
+        "time": "int32",
+    }
 
     # Verify variables
-    # 3 dim coords (excluding shot_index) + 5 non-dim coords + 1 data + 1 trace mask + 1 headers = 11 variables
+    # 4 dim coords + 4 non-dim coords + 1 data + 1 trace mask + 1 headers = 11 variables
     assert len(dataset.variables) == 11
 
     # Verify trace headers
@@ -54,11 +58,8 @@ def _validate_coordinates_headers_trace_mask(dataset: Dataset, headers: Structur
         dtype=ScalarType.BOOL,
     )
 
-    # Verify dimension coordinate variables (excluding shot_index which is calculated)
+    # Verify dimension coordinate variables
     for dim_name, dim_size in DATASET_SIZE_MAP.items():
-        if dim_name == "shot_index":
-            continue
-
         validate_variable(
             dataset,
             name=dim_name,
@@ -86,18 +87,6 @@ def _validate_coordinates_headers_trace_mask(dataset: Dataset, headers: Structur
     )
     assert receiver_y.metadata.units_v1.length == LengthUnitEnum.METER
 
-    # Verify shot_point coordinate (logical)
-    validate_variable(
-        dataset,
-        name="shot_point",
-        dims=[
-            ("shot_line", DATASET_SIZE_MAP["shot_line"]),
-            ("shot_index", DATASET_SIZE_MAP["shot_index"]),
-        ],
-        coords=["shot_point"],
-        dtype=ScalarType.UINT32,
-    )
-
     # Verify source coordinate variables
     for coord_name in ["source_coord_x", "source_coord_y"]:
         coord = validate_variable(
@@ -105,7 +94,7 @@ def _validate_coordinates_headers_trace_mask(dataset: Dataset, headers: Structur
             name=coord_name,
             dims=[
                 ("shot_line", DATASET_SIZE_MAP["shot_line"]),
-                ("shot_index", DATASET_SIZE_MAP["shot_index"]),
+                ("shot_point", DATASET_SIZE_MAP["shot_point"]),
             ],
             coords=[coord_name],
             dtype=ScalarType.FLOAT64,
@@ -122,10 +111,10 @@ class TestSeismic3DReceiverGathersTemplate:
 
         # Template attributes
         assert t.name == "ReceiverGathers3D"
-        assert t._dim_names == ("receiver", "shot_line", "shot_index", "time")
-        assert t._calculated_dims == ("shot_index",)
+        assert t._dim_names == ("receiver", "shot_line", "shot_point", "time")
+        assert t._calculated_dims == ()
         assert t._physical_coord_names == ("receiver_x", "receiver_y", "source_coord_x", "source_coord_y")
-        assert t._logical_coord_names == ("shot_point",)
+        assert t._logical_coord_names == ()
         assert t.full_chunk_shape == (1, 1, 512, 4096)
 
         # Variables instantiated when build_dataset() is called


### PR DESCRIPTION
This template was never supposed to have a calculated `shot_index`. As such, this was not ingestible.